### PR TITLE
Add Fahrenheit support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,136 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask instance folder
+instance/
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/dictionaries
+.idea/vcs.xml
+.idea/jsLibraryMappings.xml
+
+# Sensitive or high-churn files:
+.idea/dataSources.ids
+.idea/dataSources.xml
+.idea/dataSources.local.xml
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml
+
+# Gradle:
+.idea/gradle.xml
+.idea/libraries
+
+# Mongo Explorer plugin:
+.idea/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -39,7 +39,8 @@ https://github.com/bewest/decoding-carelink/pull/171
 
 Note that you can run fuscus in a *screen* session for experimenting, or
 you can add the command to start fuscus to the fuscus user's crontab in
-a *@reboot* entry.  
+a *@reboot* entry.  An example @reboot entry which discards normal output and logs everything sent to stderr is:
+*@reboot sudo /<path to fuscus>/fuscus.py -c /<path to fuscus>/fuscus.ini 1>/dev/null 2>>/home/fuscus/stderr.txt &*
 
 When fuscus is running it will listen on /dev/fuscus for a connection
 from BrewPi.  BrewPi will attempt to connect every minute.  This means
@@ -57,4 +58,6 @@ Change the port variable in the config.cfg file from this:
 port = /dev/ttyACM0
 to
 port = socket://localhost:25518
+
+Fully test the Fahrenheit conversion code to ensure that it works properly with beer profiles
 

--- a/fuscus/displayLCD.py
+++ b/fuscus/displayLCD.py
@@ -44,7 +44,7 @@ LCD_FLAG_DISPLAY_ROOM = 0x01
 LCD_FLAG_ALTERNATE_ROOM = 0x02
 
 # Variables.  #FIXME consider making a class, with these as class variables
-flags = LCD_FLAG_ALTERNATE_ROOM
+flags = LCD_FLAG_ALTERNATE_ROOM  # TODO - Change this so that it disables if room sensor is None
 stateOnDisplay = None
 
 
@@ -208,21 +208,21 @@ def printAllTemperatures():
 
 
 def printBeerTemp():
-	printTemperatureAt(6, 1, tempControl.getBeerTemp())
+	printTemperatureAt(6, 1, tempControl.temp_convert_to_external(tempControl.getBeerTemp()))
 
 
 def printBeerSet():
-	printTemperatureAt(12, 1, tempControl.getBeerSetting())
+	printTemperatureAt(12, 1, tempControl.temp_convert_to_external(tempControl.getBeerSetting()))
 
 
 def printFridgeTemp():
-	printTemperatureAt(6,2, tempControl.ambientSensor.temperature
+	printTemperatureAt(6,2, tempControl.temp_convert_to_external(tempControl.ambientSensor.temperature)
 					if (flags & LCD_FLAG_DISPLAY_ROOM)
-					else tempControl.getFridgeTemp())
+					else tempControl.temp_convert_to_external(tempControl.getFridgeTemp()))
 
 
 def printFridgeSet():
-	fridgeSet = tempControl.getFridgeSetting()
+	fridgeSet = tempControl.temp_convert_to_external(tempControl.getFridgeSetting())
 	if (flags & LCD_FLAG_DISPLAY_ROOM):	# beer setting is not active
 		fridgeSet = None
 	printTemperatureAt(12, 2, fridgeSet)

--- a/fuscus/piLink.py
+++ b/fuscus/piLink.py
@@ -26,7 +26,7 @@ import sys
 import time
 import json
 import select
-import yaml	# To get around brewpi's terse JSON
+import yaml  # To get around brewpi's terse JSON
 import logging
 
 import ui
@@ -40,560 +40,556 @@ STR_BEER_TEMP = "Beer temp"
 STR_FRIDGE_TEMP = "Fridge temp"
 STR_FMT_SET_TO = " set to %s "
 
+
 class piLink:
-
-	def __init__(self, tempControl, path):
-		# Set up a pty to accept serial input as if we are an Arduino
-		# FIXME: Make this a socket interface.  The main brewpi code can send to a socket.
-		# use port 25518 (beer 2 5 5 18)
-		os.setegid(20)
-		master, slave = pty.openpty()
-		port_name = os.ttyname(slave)
-		os.chmod(port_name, 0o666)
-		
-		# Create a new symlink for our instance, as the pty
-		# number can change each time.
-		
-		# First, delete the symlink for our instance, in case
-		# we crashed last time.
-		if os.path.islink(path):
-			try:
-				os.unlink(path)
-			except Exception:
-				pass
-			
-		os.symlink(port_name, path)
-		
-		print("Listening on '%s' as '%s'"%(port_name,path))
-		self.f = os.fdopen(master, 'wb+', buffering=0)
-		self.portName = port_name
-		self.path = path
-		self.buf = ''
-		
-		self.tempControl = tempControl
-		self.tempControl.piLink = self #FIXME is this good practice?
-
-
-	def cleanup(self):
-		# Delete the symlink for our instance when we exit
-                if os.path.islink(self.path):
-                        try:
-                                os.unlink(self.path)
-                        except Exception:
-                                pass
-
-
-	def updateBuffer(self):
-		""" Fetch new data into the buffer and return the first character
-		of the buffer
-		"""
-		ready_to_read, ready_to_write, in_error = select.select([self.f], [], [], 0)
-
-		# read a byte and append it to the buffer
-		if ready_to_read:
-			self.buf += self.f.read(1).decode("utf-8")	# Convert byte to character
-
-		# return a single byte (if there is one)
-		inByte = self.buf[0:]
-		self.buf = self.buf[1:]
-		return inByte
-
-
-	def receive(self):
-
-		inByte = self.updateBuffer()
-
-		if inByte:
-
-			if inByte in [' ', '\r', '\n']:
-				pass
-
-			elif inByte == 'A':	# alarm on
-				print("Sound alarm request.  Not supported.")
-				#soundAlarm(true)
-
-			elif inByte == 'a':	# alarm off
-				print("Silence alarm request.  Not supported.")
-				#soundAlarm(false);
-
-			elif inByte == 't':	# temperatures requested
-				print("Temperature data request.")
-				self.printTemperatures()
-
-			elif inByte == 'C':	# Set default constants
-				print("Set default constants request.")
-				self.tempControl.loadDefaultConstants()
-				#display.printStationaryText()	# FIXME reprint stationary text to update to right degree unit
-				self.sendControlConstants(self.tempControl.cc)	# update script with new settings
-				logging.info("INFO_DEFAULT_CONSTANTS_LOADED")
-
-			elif inByte == 'S':	# Set default settings
-				print("Set default settings request.")
-				self.tempControl.loadDefaultSettings()
-				self.sendControlSettings(self.tempControl.cs)	# update script with new settings
-				logging.info("INFO_DEFAULT_SETTINGS_LOADED")
-
-			elif inByte == 's':	# Control settings requested
-				print("Control settings request.")
-				self.sendControlSettings(self.tempControl.cs)
-
-			elif inByte == 'c':	# Control constants requested
-				print("Control constants request.")
-				self.sendControlConstants(self.tempControl.cc)
-
-			elif inByte == 'v':	# Control variables requested
-				print("Control variables request.")
-				self.sendControlVariables(self.tempControl.cv)
-
-			elif inByte == 'n':	# Version request
-				# PSTR(VERSION_STRING), // v:
-				# PSTR(stringify(BUILD_NAME)), // n:
-				# BREWPI_STATIC_CONFIG, // s:
-				# BREWPI_SIMULATE, // y:
-				# BREWPI_BOARD, // b:
-				# BREWPI_LOG_MESSAGES_VERSION); // l:
-				print("Version request.  Sending version.")
-				vers = {"v":"0.2.11", "n":"fuscus", "s":0, "y":0, "b":"?", "l":"1"}
-				self.f.write(bytes('N:' + json.dumps(vers) + '\r\n','UTF-8'))
-
-			elif inByte == 'l':	# Display content requested
-				print("LCD content request.")
-				# Brewpi web interface has only 4 lines, so we don't send the whole buffer
-				self.f.write(bytes('L:' + json.dumps(ui.LCD.buffer[:4]) + '\r\n','UTF-8'))
-
-			elif inByte == 'j':	# Receive settings as json
-				print("Incoming JSON settings.")
-				self.receiveJson()
-
-			elif inByte == 'E':	# initialize eeprom
-				# FIXME not implemented
-				#eepromManager.initializeEeprom()
-				#logInfo(INFO_EEPROM_INITIALIZED)
-				#settingsManager.loadSettings()
-				pass
-
-			elif inByte == 'd':	# list devices in eeprom order
-				# FIXME not implemented
-				#openListResponse('d')
-				#deviceManager.listDevices(piStream)
-				#closeListResponse()
-				pass
-
-			elif inByte == 'U': # update device		
-				# FIXME not implemented
-				#deviceManager.parseDeviceDefinition(piStream)
-				pass
-				
-			elif inByte == 'h':	# hardware query
-				# FIXME not implemented
-				#openListResponse('h')
-				#deviceManager.enumerateHardwareToStream(piStream)
-				#closeListResponse()
-				pass
-
-			elif inByte == 'R':	# reset 
-				# FIXME not implemented
-				#handleReset()
-				pass
-
-			elif inByte == 'F':	# flash firmware
-				print("Flash firmware request.  Not supported.")
-				#flashFirmware()
-
-			elif inByte != '':
-				#logWarningInt(WARNING_INVALID_COMMAND, inByte);
-				print("Received '%s' character"%inByte)
-			else:
-				print("Got empty string.")
-
-
-	def printTemperaturesJSON(self, beerAnnotation, fridgeAnnotation):
-		temps = {}
-
-		# For reference (COMPACT_SERIAL codes)
-		#define JSON_BEER_TEMP  "bt"
-		#define JSON_BEER_SET	"bs"
-		#define JSON_BEER_ANN	"ba"
-		#define JSON_FRIDGE_TEMP "ft"
-		#define JSON_FRIDGE_SET  "fs"
-		#define JSON_FRIDGE_ANN  "fa"
-		#define JSON_STATE		"s"
-		#define JSON_TIME		"t"
-		#define JSON_ROOM_TEMP  "rt"
-
-		'''COMPACT_SERIAL is not in use
-		t = self.tempControl.getBeerTemp()
-		if t:
-			temps['bt'] = t
-
-		t = self.tempControl.getBeerSetting()
-		if t:
-			temps['bs'] = t
-
-		if beerAnnotation:
-			temps['ba'] = beerAnnotation
-
-		t = self.tempControl.getFridgeTemp()
-		if t:
-			temps['ft'] = t
-
-		t = self.tempControl.getFridgeSetting()
-		if t:
-			temps['fs'] = t
-
-		if fridgeAnnotation:
-			temps['fa'] = fridgeAnnotation
-
-		t = self.tempControl.getRoomTemp()
-		if t:
-			temps['rt'] = t
-
-		temps['s'] = self.tempControl.getState()'''
-
-		# These field names are in use
-		#define JSON_BEER_TEMP  "BeerTemp"
-		#define JSON_BEER_SET   "BeerSet"
-		#define JSON_BEER_ANN   "BeerAnn"
-		#define JSON_FRIDGE_TEMP "FridgeTemp"
-		#define JSON_FRIDGE_SET  "FridgeSet"
-		#define JSON_FRIDGE_ANN  "FridgeAnn"
-		#define JSON_STATE              "State"
-		#define JSON_TIME               "Time"
-		#define JSON_ROOM_TEMP  "RoomTemp"
-
-		temps['BeerTemp'] = self.tempControl.getBeerTemp()
-		temps['BeerSet'] = self.tempControl.getBeerSetting()
-		temps['BeerAnn'] = beerAnnotation
-		temps['FridgeTemp'] = self.tempControl.getFridgeTemp()
-		temps['FridgeSet'] = self.tempControl.getFridgeSetting()
-		temps['FridgeAnn'] = fridgeAnnotation
-
-		t = self.tempControl.getRoomTemp()	# Room temp sensor may not be present
-		if t:
-			temps['RoomTemp'] = t
-
-		temps['State'] = self.tempControl.getState()
-
-
-		self.f.write(bytes('T:'+json.dumps(temps)+'\r\n','UTF-8'))
-
-
-	def printBeerAnnotation(self, annotation):
-		self.printTemperaturesJSON(annotation, None)
-
-
-	def printFridgeAnnotation(self, annotation):
-		self.printTemperaturesJSON(None, annotation)
-
-
-	#def printResponse(type):
-	#	pass
-	#def openListResponse(type):
-	#	pass
-	#def closeListResponse():
-	#	pass
-
-
-	def debugMessage(message, *args):
-		# FIXME: This probably won't work either
-		return 'D' + message % args + '\r\n'
-
-
-	#def sendJsonClose():
-	#	pass
-
-
-	def printTemperatures(self):
-		"""Print all temperatures with empty annotations."""
-		self.printTemperaturesJSON(None, None)
-
-
-	# If the JSONKEYs were the same as the variable names, we could do this:
-	#	return 'C:'+json.dumps(vars(cc))+'\r\n'
-	# Instead we have to do it the hard way
-
-	def sendControlSettings(self, cs):
-		d = vars(cs).copy()
-		# Fix up the key names that are not the same
-		d[JSONKEY_beerSetting] = d.pop('beerSetting')
-		d[JSONKEY_fridgeSetting] = d.pop('fridgeSetting')
-		d[JSONKEY_heatEstimator] = d.pop('heatEstimator')
-		d[JSONKEY_coolEstimator] = d.pop('coolEstimator')
-
-		self.f.write(bytes('S:'+json.dumps(d)+'\r\n','UTF-8'))
-
-
-	def sendControlConstants(self, cc):
-		d = vars(cc).copy()
-		# Fix up the key names that are not the same
-		d[JSONKEY_tempSettingMin] = d.pop('tempSettingMin')
-		d[JSONKEY_tempSettingMax] = d.pop('tempSettingMax')
-		d[JSONKEY_iMaxError] = d.pop('iMaxError')
-		d[JSONKEY_idleRangeHigh] = d.pop('idleRangeHigh')
-
-		d[JSONKEY_idleRangeLow] = d.pop('idleRangeLow')
-		d[JSONKEY_heatingTargetUpper] = d.pop('heatingTargetUpper')
-		d[JSONKEY_heatingTargetLower] = d.pop('heatingTargetLower')
-		d[JSONKEY_coolingTargetUpper] = d.pop('coolingTargetUpper')
-		d[JSONKEY_coolingTargetLower] = d.pop('coolingTargetLower')
-		d[JSONKEY_maxHeatTimeForEstimate] = d.pop('maxHeatTimeForEstimate')
-		d[JSONKEY_maxCoolTimeForEstimate] = d.pop('maxCoolTimeForEstimate')
-		d[JSONKEY_fridgeFastFilter] = d.pop('fridgeFastFilter')
-		d[JSONKEY_fridgeSlowFilter] = d.pop('fridgeSlowFilter')
-		d[JSONKEY_fridgeSlopeFilter] = d.pop('fridgeSlopeFilter')
-		d[JSONKEY_beerFastFilter] = d.pop('beerFastFilter')
-		d[JSONKEY_beerSlowFilter] = d.pop('beerSlowFilter')
-		d[JSONKEY_beerSlopeFilter] = d.pop('beerSlopeFilter')
-		d[JSONKEY_lightAsHeater] = d.pop('lightAsHeater')
-		d[JSONKEY_rotaryHalfSteps] = d.pop('rotaryHalfSteps')
-
-		self.f.write(bytes('C:'+json.dumps(d)+'\r\n','UTF-8'))
-
-
-	def sendControlVariables(self, cv):
-		d = vars(cv).copy()
-		# Fix up the key names that are not the same
-		d[JSONKEY_estimatedPeak] = d.pop('estimatedPeak')
-		d[JSONKEY_negPeakEstimate] = d.pop('negPeakEstimate')
-		d[JSONKEY_posPeakEstimate] = d.pop('posPeakEstimate')
-
-		self.f.write(bytes('V:'+json.dumps(d)+'\r\n','UTF-8'))
-
-
-	def receiveControlConstants():
-		# This does not seem to be defined in the original source
-		pass	
-
-
-	def receiveJson(self):	# receive settings as JSON key:value pairs
-		jsonBuf = ''
-		while 1:	# FIXME Implement a one-second timeout here
-			print("Timeout needed!")
-			inByte = self.updateBuffer()
-			jsonBuf += inByte
-			if inByte == '}':
-				break
-
-		jsonBuf = jsonBuf.replace(':',': ')	# Fixup hacked JSON so YAML can read it
-
-		newSettings = yaml.load(jsonBuf)
-
-		print("New settings %s"%newSettings)
-
-		# JSON_CONVERT(JSONKEY_mode, NULL, setMode),
-		# JSON_CONVERT(JSONKEY_beerSetting, NULL, setBeerSetting),
-		# JSON_CONVERT(JSONKEY_fridgeSetting, NULL, setFridgeSetting),
-
-		if JSONKEY_mode in newSettings:
-			self.setMode(newSettings[JSONKEY_mode])
-		if JSONKEY_beerSetting in newSettings:
-			self.setBeerSetting(newSettings[JSONKEY_beerSetting])
-		if JSONKEY_fridgeSetting in newSettings:
-			self.setFridgeSetting(newSettings[JSONKEY_fridgeSetting])
-
-		# JSON_CONVERT(JSONKEY_heatEstimator, &tempControl.cs.heatEstimator, setStringToFixedPoint),
-		# JSON_CONVERT(JSONKEY_coolEstimator, &tempControl.cs.coolEstimator, setStringToFixedPoint),
-
-		if JSONKEY_heatEstimator in newSettings:
-			self.tempControl.cs.heatEstimator = float(newSettings[JSONKEY_heatEstimator])
-
-		if JSONKEY_coolEstimator in newSettings:
-			self.tempControl.cs.coolEstimator = float(newSettings[JSONKEY_coolEstimator])
-
-		#JSON_CONVERT(JSONKEY_tempFormat, NULL, setTempFormat),
-
-		if JSONKEY_tempFormat in newSettings:
-			self.setTempFormat(newSettings[JSONKEY_tempFormat])
-		
-		# JSON_CONVERT(JSONKEY_tempSettingMin, &tempControl.cc.tempSettingMin, setStringToTemp),
-		# JSON_CONVERT(JSONKEY_tempSettingMax, &tempControl.cc.tempSettingMax, setStringToTemp),
-		# JSON_CONVERT(JSONKEY_pidMax, &tempControl.cc.pidMax, setStringToTempDiff),
-
-		if JSONKEY_tempSettingMin in newSettings:
-			self.tempControl.cc.tempSettingMin = float(newSettings[JSONKEY_tempSettingMin])
-
-		if JSONKEY_tempSettingMax in newSettings:
-			self.tempControl.cc.tempSettingMax = float(newSettings[JSONKEY_tempSettingMax])
-
-		# JSON_CONVERT(JSONKEY_Kp, &tempControl.cc.Kp, setStringToFixedPoint),
-		# JSON_CONVERT(JSONKEY_Ki, &tempControl.cc.Ki, setStringToFixedPoint),
-		# JSON_CONVERT(JSONKEY_Kd, &tempControl.cc.Kd, setStringToFixedPoint),
-
-		if JSONKEY_Kp in newSettings:
-			self.tempControl.cc.Kp = float(newSettings[JSONKEY_Kp])
-
-		if JSONKEY_Ki in newSettings:
-			self.tempControl.cc.Ki = float(newSettings[JSONKEY_Ki])
-			
-		if JSONKEY_Kd in newSettings:
-			self.tempControl.cc.Kd = float(newSettings[JSONKEY_Kd])
-			
-		# JSON_CONVERT(JSONKEY_iMaxError, &tempControl.cc.iMaxError, setStringToTempDiff),
-		# JSON_CONVERT(JSONKEY_idleRangeHigh, &tempControl.cc.idleRangeHigh, setStringToTempDiff),
-		# JSON_CONVERT(JSONKEY_idleRangeLow, &tempControl.cc.idleRangeLow, setStringToTempDiff),
-		# JSON_CONVERT(JSONKEY_heatingTargetUpper, &tempControl.cc.heatingTargetUpper, setStringToTempDiff),
-		# JSON_CONVERT(JSONKEY_heatingTargetLower, &tempControl.cc.heatingTargetLower, setStringToTempDiff),
-		# JSON_CONVERT(JSONKEY_coolingTargetUpper, &tempControl.cc.coolingTargetUpper, setStringToTempDiff),
-		# JSON_CONVERT(JSONKEY_coolingTargetLower, &tempControl.cc.coolingTargetLower, setStringToTempDiff),
-		# JSON_CONVERT(JSONKEY_maxHeatTimeForEstimate, &tempControl.cc.maxHeatTimeForEstimate, setUint16),
-		# JSON_CONVERT(JSONKEY_maxCoolTimeForEstimate, &tempControl.cc.maxCoolTimeForEstimate, setUint16),
-		# JSON_CONVERT(JSONKEY_lightAsHeater, &tempControl.cc.lightAsHeater, setBool),
-		# JSON_CONVERT(JSONKEY_rotaryHalfSteps, &tempControl.cc.rotaryHalfSteps, setBool),
-
-		if JSONKEY_iMaxError in newSettings:
-			self.tempControl.cc.iMaxError = float(newSettings[JSONKEY_iMaxError])
-
-		if JSONKEY_idleRangeHigh in newSettings:
-			self.tempControl.cc.idleRangeHigh = float(newSettings[JSONKEY_idleRangeHigh])
-			
-		if JSONKEY_idleRangeLow in newSettings:
-			self.tempControl.cc.idleRangeLow = float(newSettings[JSONKEY_idleRangeLow])
-
-		if JSONKEY_heatingTargetUpper in newSettings:
-			self.tempControl.cc.heatingTargetUpper = float(newSettings[JSONKEY_heatingTargetUpper])
-			
-		if JSONKEY_heatingTargetLower in newSettings:
-			self.tempControl.cc.heatingTargetLower = float(newSettings[JSONKEY_heatingTargetLower])
-			
-		if JSONKEY_coolingTargetUpper in newSettings:
-			self.tempControl.cc.coolingTargetUpper = float(newSettings[JSONKEY_coolingTargetUpper])
-			
-		if JSONKEY_coolingTargetLower in newSettings:
-			self.tempControl.cc.coolingTargetLower = float(newSettings[JSONKEY_coolingTargetLower])
-			
-		if JSONKEY_maxHeatTimeForEstimate in newSettings:
-			self.tempControl.cc.maxHeatTimeForEstimate = int(newSettings[JSONKEY_maxHeatTimeForEstimate])
-			
-		if JSONKEY_maxCoolTimeForEstimate in newSettings:
-			self.tempControl.cc.maxCoolTimeForEstimate = int(newSettings[JSONKEY_maxCoolTimeForEstimate])
-
-		if JSONKEY_lightAsHeater in newSettings:
-			self.tempControl.cc.lightAsHeater = int(newSettings[JSONKEY_lightAsHeater])
-
-		if JSONKEY_rotaryHalfSteps in newSettings:
-			self.tempControl.cc.rotaryHalfSteps = int(newSettings[JSONKEY_rotaryHalfSteps])
-			
-		print(vars(self.tempControl.cc))
-
-		# FIXME Still to do	
-		# JSON_CONVERT(JSONKEY_fridgeFastFilter, MAKE_FILTER_SETTING_TARGET(FAST, FRIDGE), applyFilterSetting),
-		# JSON_CONVERT(JSONKEY_fridgeSlowFilter, MAKE_FILTER_SETTING_TARGET(SLOW, FRIDGE), applyFilterSetting),
-		# JSON_CONVERT(JSONKEY_fridgeSlopeFilter, MAKE_FILTER_SETTING_TARGET(SLOPE, FRIDGE), applyFilterSetting),
-		# JSON_CONVERT(JSONKEY_beerFastFilter, MAKE_FILTER_SETTING_TARGET(FAST, BEER), applyFilterSetting),
-		# JSON_CONVERT(JSONKEY_beerSlowFilter, MAKE_FILTER_SETTING_TARGET(SLOW, BEER), applyFilterSetting),
-		# JSON_CONVERT(JSONKEY_beerSlopeFilter, MAKE_FILTER_SETTING_TARGET(SLOPE, BEER), applyFilterSetting)
-			
-
-	# FIXME A lot of unneeded code copied from original source should be deleted
-	#static void (*ParseJsonCallback)(const char* key, const char* val, void* data);
-
-	#static void parseJson(ParseJsonCallback fn, void* data=NULL);
-			
-	#	static void print(char *fmt, ...); // use when format string is stored in RAM
-	#	static void print(char c)       // inline for arduino
-	#ifdef ARDUINO        
-	#         { Serial.print(c); } 
-	#else
-	#        ;
-	#endif
-			
-	#	static void print_P(const char *fmt, ...); // use when format string is stored in PROGMEM with PSTR("string")
-	#	static void printNewLine(void);
-
-	def printChamberCount():
-		pass
-		
-	def soundAlarm(enabled):
-		pass
-
-	def	printChamberInfo():
-		pass
-		
-	def sendJsonPair(name, val):	# send one JSON pair with a string value as name:val,
-		pass
-	#	static void sendJsonPair(const char * name, char val); // send one JSON pair with a char value as name:val,
-	#	static void sendJsonPair(const char * name, uint16_t val); // send one JSON pair with a uint16_t value as name:val,
-	#	static void sendJsonPair(const char * name, uint8_t val); // send one JSON pair with a uint8_t value as name:val,
-	def sendJsonAnnotation(name, annotation):
-		pass
-	def sendJsonTemp(name, temp):
-		pass
-		
-	def processJsonPair(key, val,  pv):	# process one pair
-		pass
-		
-	#	/* Prints the name part of a json name/value pair. The name must exist in PROGMEM */
-	def printJsonName(name):
-		pass
-	def	printJsonSeparator():
-		pass
-		
-
-	#	struct JsonOutput {
-	#		const char* key;			// JSON key
-	#		uint8_t offset;			// offset into TempControl class
-	#		uint8_t handlerOffset;		// handler index
-	#	};
-	#	typedef void (*JsonOutputHandler)(const char* key, uint8_t offset);
-	#	static void sendJsonValues(char responseType, const JsonOutput* /*PROGMEM*/ jsonOutputMap, uint8_t mapCount);
-
-
-	# handler functions for JSON output
-	def jsonOutputUint8(key, offset):
-		pass
-	def jsonOutputTempToString(key, offset):
-		pass
-	def jsonOutputFixedPointToString(key, offset):
-		pass
-	def jsonOutputTempDiffToString(key, offset):
-		pass
-	def jsonOutputChar(key, offset):
-		pass
-	def jsonOutputUint16(key, offset):
-		pass
-	#	static const JsonOutputHandler JsonOutputHandlers[];		
-	#	static const JsonOutput jsonOutputCCMap[];
-	#	static const JsonOutput jsonOutputCVMap[];
-
-	# Json parsing
-
-	def setMode(self, val):
-		mode = val[0]
-		self.tempControl.setMode(mode)
-		self.printFridgeAnnotation(STR_MODE + (STR_FMT_SET_TO%val) + STR_WEB_INTERFACE)
-
-		
-	def setBeerSetting(self, newTemp):
-		source = None
-		if (self.tempControl.cs.mode == 'p'):
-			if(self.tempControl.cs.beerSetting is not None and (abs(newTemp - self.tempControl.cs.beerSetting) > 0.2)):	# this excludes gradual updates under 0.2 degrees
-				source = STR_TEMPERATURE_PROFILE
-		else:
-			source = STR_WEB_INTERFACE
-		
-		if (source):
-			self.printBeerAnnotation(STR_BEER_TEMP + (STR_FMT_SET_TO%newTemp) + source)
-
-		self.tempControl.setBeerTemp(newTemp)
-
-		
-	def setFridgeSetting(self, newTemp):
-		if (self.tempControl.cs.mode == 'f'):
-			self.printFridgeAnnotation(STR_FRIDGE_TEMP + (STR_FMT_SET_TO%newTemp) + STR_WEB_INTERFACE)
-
-		self.tempControl.setFridgeTemp(newTemp)
-
-
-	def	setTempFormat(self, val):
-		# Only Celsius for now
-		pass
-
-	#	typedef void (*JsonParserHandlerFn)(const char* val, void* target);	
-
-	#	struct JsonParserConvert {
-	#		const char* /*PROGMEM*/ key;
-	#		void* target;
-	#		JsonParserHandlerFn fn;
-	#	};
-
-	#	static const JsonParserConvert jsonParserConverters[];	
+    def __init__(self, tempControl, path):
+        # Set up a pty to accept serial input as if we are an Arduino
+        # FIXME: Make this a socket interface.  The main brewpi code can send to a socket.
+        # use port 25518 (beer 2 5 5 18)
+        os.setegid(20)
+        master, slave = pty.openpty()
+        port_name = os.ttyname(slave)
+        os.chmod(port_name, 0o666)
+
+        # Create a new symlink for our instance, as the pty
+        # number can change each time.
+
+        # First, delete the symlink for our instance, in case
+        # we crashed last time.
+        if os.path.islink(path):
+            try:
+                os.unlink(path)
+            except Exception:
+                pass
+
+        os.symlink(port_name, path)
+
+        print("Listening on '%s' as '%s'" % (port_name, path))
+        self.f = os.fdopen(master, 'wb+', buffering=0)
+        self.portName = port_name
+        self.path = path
+        self.buf = ''
+
+        self.tempControl = tempControl
+        self.tempControl.piLink = self  # FIXME is this good practice?
+
+    def cleanup(self):
+        # Delete the symlink for our instance when we exit
+        if os.path.islink(self.path):
+            try:
+                os.unlink(self.path)
+            except Exception:
+                pass
+
+    def updateBuffer(self):
+        """ Fetch new data into the buffer and return the first character
+        of the buffer
+        """
+        ready_to_read, ready_to_write, in_error = select.select([self.f], [], [], 0)
+
+        # read a byte and append it to the buffer
+        if ready_to_read:
+            self.buf += self.f.read(1).decode("utf-8")  # Convert byte to character
+
+        # return a single byte (if there is one)
+        inByte = self.buf[0:]
+        self.buf = self.buf[1:]
+        return inByte
+
+    def receive(self):
+
+        inByte = self.updateBuffer()
+
+        if inByte:
+
+            if inByte in [' ', '\r', '\n']:
+                pass
+
+            elif inByte == 'A':  # alarm on
+                print("Sound alarm request.  Not supported.")
+                # soundAlarm(true)
+
+            elif inByte == 'a':  # alarm off
+                print("Silence alarm request.  Not supported.")
+                # soundAlarm(false);
+
+            elif inByte == 't':  # temperatures requested
+                print("Temperature data request.")
+                self.printTemperatures()
+
+            elif inByte == 'C':  # Set default constants
+                print("Set default constants request.")
+                self.tempControl.loadDefaultConstants()
+                # display.printStationaryText()	# FIXME reprint stationary text to update to right degree unit
+                self.sendControlConstants(self.tempControl.cc)  # update script with new settings
+                logging.info("INFO_DEFAULT_CONSTANTS_LOADED")
+
+            elif inByte == 'S':  # Set default settings
+                print("Set default settings request.")
+                self.tempControl.loadDefaultSettings()
+                self.sendControlSettings(self.tempControl.cs)  # update script with new settings
+                logging.info("INFO_DEFAULT_SETTINGS_LOADED")
+
+            elif inByte == 's':  # Control settings requested
+                print("Control settings request.")
+                self.sendControlSettings(self.tempControl.cs)
+
+            elif inByte == 'c':  # Control constants requested
+                print("Control constants request.")
+                self.sendControlConstants(self.tempControl.cc)
+
+            elif inByte == 'v':  # Control variables requested
+                print("Control variables request.")
+                self.sendControlVariables(self.tempControl.cv)
+
+            elif inByte == 'n':  # Version request
+                # PSTR(VERSION_STRING), // v:
+                # PSTR(stringify(BUILD_NAME)), // n:
+                # BREWPI_STATIC_CONFIG, // s:
+                # BREWPI_SIMULATE, // y:
+                # BREWPI_BOARD, // b:
+                # BREWPI_LOG_MESSAGES_VERSION); // l:
+                print("Version request.  Sending version.")
+                vers = {"v": "0.2.11", "n": "fuscus", "s": 0, "y": 0, "b": "?", "l": "1"}
+                self.f.write(bytes('N:' + json.dumps(vers) + '\r\n', 'UTF-8'))
+
+            elif inByte == 'l':  # Display content requested
+                print("LCD content request.")
+                # Brewpi web interface has only 4 lines, so we don't send the whole buffer
+                self.f.write(bytes('L:' + json.dumps(ui.LCD.buffer[:4]) + '\r\n', 'UTF-8'))
+
+            elif inByte == 'j':  # Receive settings as json
+                print("Incoming JSON settings.")
+                self.receiveJson()
+
+            elif inByte == 'E':  # initialize eeprom
+                # FIXME not implemented
+                # eepromManager.initializeEeprom()
+                # logInfo(INFO_EEPROM_INITIALIZED)
+                # settingsManager.loadSettings()
+                pass
+
+            elif inByte == 'd':  # list devices in eeprom order
+                # FIXME not implemented
+                # openListResponse('d')
+                # deviceManager.listDevices(piStream)
+                # closeListResponse()
+                pass
+
+            elif inByte == 'U':  # update device
+                # FIXME not implemented
+                # deviceManager.parseDeviceDefinition(piStream)
+                pass
+
+            elif inByte == 'h':  # hardware query
+                # FIXME not implemented
+                # openListResponse('h')
+                # deviceManager.enumerateHardwareToStream(piStream)
+                # closeListResponse()
+                pass
+
+            elif inByte == 'R':  # reset
+                # FIXME not implemented
+                # handleReset()
+                pass
+
+            elif inByte == 'F':  # flash firmware
+                print("Flash firmware request.  Not supported.")
+                # flashFirmware()
+
+            elif inByte != '':
+                # logWarningInt(WARNING_INVALID_COMMAND, inByte);
+                print("Received '%s' character" % inByte)
+            else:
+                print("Got empty string.")
+
+    def printTemperaturesJSON(self, beerAnnotation, fridgeAnnotation):
+        temps = {}
+
+        # For reference (COMPACT_SERIAL codes)
+        # define JSON_BEER_TEMP  "bt"
+        # define JSON_BEER_SET	"bs"
+        # define JSON_BEER_ANN	"ba"
+        # define JSON_FRIDGE_TEMP "ft"
+        # define JSON_FRIDGE_SET  "fs"
+        # define JSON_FRIDGE_ANN  "fa"
+        # define JSON_STATE		"s"
+        # define JSON_TIME		"t"
+        # define JSON_ROOM_TEMP  "rt"
+
+        '''COMPACT_SERIAL is not in use
+        t = self.tempControl.getBeerTemp()
+        if t:
+            temps['bt'] = t
+
+        t = self.tempControl.getBeerSetting()
+        if t:
+            temps['bs'] = t
+
+        if beerAnnotation:
+            temps['ba'] = beerAnnotation
+
+        t = self.tempControl.getFridgeTemp()
+        if t:
+            temps['ft'] = t
+
+        t = self.tempControl.getFridgeSetting()
+        if t:
+            temps['fs'] = t
+
+        if fridgeAnnotation:
+            temps['fa'] = fridgeAnnotation
+
+        t = self.tempControl.getRoomTemp()
+        if t:
+            temps['rt'] = t
+
+        temps['s'] = self.tempControl.getState()'''
+
+        # These field names are in use
+        # define JSON_BEER_TEMP  "BeerTemp"
+        # define JSON_BEER_SET   "BeerSet"
+        # define JSON_BEER_ANN   "BeerAnn"
+        # define JSON_FRIDGE_TEMP "FridgeTemp"
+        # define JSON_FRIDGE_SET  "FridgeSet"
+        # define JSON_FRIDGE_ANN  "FridgeAnn"
+        # define JSON_STATE              "State"
+        # define JSON_TIME               "Time"
+        # define JSON_ROOM_TEMP  "RoomTemp"
+
+        temps['BeerTemp'] = self.tempControl.getBeerTemp()
+        temps['BeerSet'] = self.tempControl.getBeerSetting()
+        temps['BeerAnn'] = beerAnnotation
+        temps['FridgeTemp'] = self.tempControl.getFridgeTemp()
+        temps['FridgeSet'] = self.tempControl.getFridgeSetting()
+        temps['FridgeAnn'] = fridgeAnnotation
+
+        t = self.tempControl.getRoomTemp()  # Room temp sensor may not be present
+        if t:
+            temps['RoomTemp'] = t
+
+        temps['State'] = self.tempControl.getState()
+
+        self.f.write(bytes('T:' + json.dumps(temps) + '\r\n', 'UTF-8'))
+
+    def printBeerAnnotation(self, annotation):
+        self.printTemperaturesJSON(annotation, None)
+
+    def printFridgeAnnotation(self, annotation):
+        self.printTemperaturesJSON(None, annotation)
+
+        # def printResponse(type):
+
+    #	pass
+    # def openListResponse(type):
+    #	pass
+    # def closeListResponse():
+    #	pass
+
+
+    def debugMessage(message, *args):
+        # FIXME: This probably won't work either
+        return 'D' + message % args + '\r\n'
+
+        # def sendJsonClose():
+
+    #	pass
+
+
+    def printTemperatures(self):
+        """Print all temperatures with empty annotations."""
+        self.printTemperaturesJSON(None, None)
+
+    # If the JSONKEYs were the same as the variable names, we could do this:
+    #	return 'C:'+json.dumps(vars(cc))+'\r\n'
+    # Instead we have to do it the hard way
+
+    def sendControlSettings(self, cs):
+        d = vars(cs).copy()
+        # Fix up the key names that are not the same
+        d[JSONKEY_beerSetting] = d.pop('beerSetting')
+        d[JSONKEY_fridgeSetting] = d.pop('fridgeSetting')
+        d[JSONKEY_heatEstimator] = d.pop('heatEstimator')
+        d[JSONKEY_coolEstimator] = d.pop('coolEstimator')
+
+        self.f.write(bytes('S:' + json.dumps(d) + '\r\n', 'UTF-8'))
+
+    def sendControlConstants(self, cc):
+        d = vars(cc).copy()
+        # Fix up the key names that are not the same
+        d[JSONKEY_tempSettingMin] = d.pop('tempSettingMin')
+        d[JSONKEY_tempSettingMax] = d.pop('tempSettingMax')
+        d[JSONKEY_iMaxError] = d.pop('iMaxError')
+        d[JSONKEY_idleRangeHigh] = d.pop('idleRangeHigh')
+
+        d[JSONKEY_idleRangeLow] = d.pop('idleRangeLow')
+        d[JSONKEY_heatingTargetUpper] = d.pop('heatingTargetUpper')
+        d[JSONKEY_heatingTargetLower] = d.pop('heatingTargetLower')
+        d[JSONKEY_coolingTargetUpper] = d.pop('coolingTargetUpper')
+        d[JSONKEY_coolingTargetLower] = d.pop('coolingTargetLower')
+        d[JSONKEY_maxHeatTimeForEstimate] = d.pop('maxHeatTimeForEstimate')
+        d[JSONKEY_maxCoolTimeForEstimate] = d.pop('maxCoolTimeForEstimate')
+        d[JSONKEY_fridgeFastFilter] = d.pop('fridgeFastFilter')
+        d[JSONKEY_fridgeSlowFilter] = d.pop('fridgeSlowFilter')
+        d[JSONKEY_fridgeSlopeFilter] = d.pop('fridgeSlopeFilter')
+        d[JSONKEY_beerFastFilter] = d.pop('beerFastFilter')
+        d[JSONKEY_beerSlowFilter] = d.pop('beerSlowFilter')
+        d[JSONKEY_beerSlopeFilter] = d.pop('beerSlopeFilter')
+        d[JSONKEY_lightAsHeater] = d.pop('lightAsHeater')
+        d[JSONKEY_rotaryHalfSteps] = d.pop('rotaryHalfSteps')
+
+        self.f.write(bytes('C:' + json.dumps(d) + '\r\n', 'UTF-8'))
+
+    def sendControlVariables(self, cv):
+        d = vars(cv).copy()
+        # Fix up the key names that are not the same
+        d[JSONKEY_estimatedPeak] = d.pop('estimatedPeak')
+        d[JSONKEY_negPeakEstimate] = d.pop('negPeakEstimate')
+        d[JSONKEY_posPeakEstimate] = d.pop('posPeakEstimate')
+
+        self.f.write(bytes('V:' + json.dumps(d) + '\r\n', 'UTF-8'))
+
+    def receiveControlConstants():
+        # This does not seem to be defined in the original source
+        pass
+
+    def receiveJson(self):  # receive settings as JSON key:value pairs
+        jsonBuf = ''
+        while 1:  # FIXME Implement a one-second timeout here
+            print("Timeout needed!")
+            inByte = self.updateBuffer()
+            jsonBuf += inByte
+            if inByte == '}':
+                break
+
+        jsonBuf = jsonBuf.replace(':', ': ')  # Fixup hacked JSON so YAML can read it
+
+        newSettings = yaml.load(jsonBuf)
+
+        print("New settings %s" % newSettings)
+
+        # JSON_CONVERT(JSONKEY_mode, NULL, setMode),
+        # JSON_CONVERT(JSONKEY_beerSetting, NULL, setBeerSetting),
+        # JSON_CONVERT(JSONKEY_fridgeSetting, NULL, setFridgeSetting),
+
+        if JSONKEY_mode in newSettings:
+            self.setMode(newSettings[JSONKEY_mode])
+        if JSONKEY_beerSetting in newSettings:
+            self.setBeerSetting(newSettings[JSONKEY_beerSetting])
+        if JSONKEY_fridgeSetting in newSettings:
+            self.setFridgeSetting(newSettings[JSONKEY_fridgeSetting])
+
+        # JSON_CONVERT(JSONKEY_heatEstimator, &tempControl.cs.heatEstimator, setStringToFixedPoint),
+        # JSON_CONVERT(JSONKEY_coolEstimator, &tempControl.cs.coolEstimator, setStringToFixedPoint),
+
+        if JSONKEY_heatEstimator in newSettings:
+            self.tempControl.cs.heatEstimator = float(newSettings[JSONKEY_heatEstimator])
+
+        if JSONKEY_coolEstimator in newSettings:
+            self.tempControl.cs.coolEstimator = float(newSettings[JSONKEY_coolEstimator])
+
+            # JSON_CONVERT(JSONKEY_tempFormat, NULL, setTempFormat),
+
+        if JSONKEY_tempFormat in newSettings:
+            self.setTempFormat(newSettings[JSONKEY_tempFormat])
+
+        # JSON_CONVERT(JSONKEY_tempSettingMin, &tempControl.cc.tempSettingMin, setStringToTemp),
+        # JSON_CONVERT(JSONKEY_tempSettingMax, &tempControl.cc.tempSettingMax, setStringToTemp),
+        # JSON_CONVERT(JSONKEY_pidMax, &tempControl.cc.pidMax, setStringToTempDiff),
+
+        if JSONKEY_tempSettingMin in newSettings:
+            self.tempControl.cc.tempSettingMin = float(newSettings[JSONKEY_tempSettingMin])
+
+        if JSONKEY_tempSettingMax in newSettings:
+            self.tempControl.cc.tempSettingMax = float(newSettings[JSONKEY_tempSettingMax])
+
+        # JSON_CONVERT(JSONKEY_Kp, &tempControl.cc.Kp, setStringToFixedPoint),
+        # JSON_CONVERT(JSONKEY_Ki, &tempControl.cc.Ki, setStringToFixedPoint),
+        # JSON_CONVERT(JSONKEY_Kd, &tempControl.cc.Kd, setStringToFixedPoint),
+
+        if JSONKEY_Kp in newSettings:
+            self.tempControl.cc.Kp = float(newSettings[JSONKEY_Kp])
+
+        if JSONKEY_Ki in newSettings:
+            self.tempControl.cc.Ki = float(newSettings[JSONKEY_Ki])
+
+        if JSONKEY_Kd in newSettings:
+            self.tempControl.cc.Kd = float(newSettings[JSONKEY_Kd])
+
+        # JSON_CONVERT(JSONKEY_iMaxError, &tempControl.cc.iMaxError, setStringToTempDiff),
+        # JSON_CONVERT(JSONKEY_idleRangeHigh, &tempControl.cc.idleRangeHigh, setStringToTempDiff),
+        # JSON_CONVERT(JSONKEY_idleRangeLow, &tempControl.cc.idleRangeLow, setStringToTempDiff),
+        # JSON_CONVERT(JSONKEY_heatingTargetUpper, &tempControl.cc.heatingTargetUpper, setStringToTempDiff),
+        # JSON_CONVERT(JSONKEY_heatingTargetLower, &tempControl.cc.heatingTargetLower, setStringToTempDiff),
+        # JSON_CONVERT(JSONKEY_coolingTargetUpper, &tempControl.cc.coolingTargetUpper, setStringToTempDiff),
+        # JSON_CONVERT(JSONKEY_coolingTargetLower, &tempControl.cc.coolingTargetLower, setStringToTempDiff),
+        # JSON_CONVERT(JSONKEY_maxHeatTimeForEstimate, &tempControl.cc.maxHeatTimeForEstimate, setUint16),
+        # JSON_CONVERT(JSONKEY_maxCoolTimeForEstimate, &tempControl.cc.maxCoolTimeForEstimate, setUint16),
+        # JSON_CONVERT(JSONKEY_lightAsHeater, &tempControl.cc.lightAsHeater, setBool),
+        # JSON_CONVERT(JSONKEY_rotaryHalfSteps, &tempControl.cc.rotaryHalfSteps, setBool),
+
+        if JSONKEY_iMaxError in newSettings:
+            self.tempControl.cc.iMaxError = float(newSettings[JSONKEY_iMaxError])
+
+        if JSONKEY_idleRangeHigh in newSettings:
+            self.tempControl.cc.idleRangeHigh = float(newSettings[JSONKEY_idleRangeHigh])
+
+        if JSONKEY_idleRangeLow in newSettings:
+            self.tempControl.cc.idleRangeLow = float(newSettings[JSONKEY_idleRangeLow])
+
+        if JSONKEY_heatingTargetUpper in newSettings:
+            self.tempControl.cc.heatingTargetUpper = float(newSettings[JSONKEY_heatingTargetUpper])
+
+        if JSONKEY_heatingTargetLower in newSettings:
+            self.tempControl.cc.heatingTargetLower = float(newSettings[JSONKEY_heatingTargetLower])
+
+        if JSONKEY_coolingTargetUpper in newSettings:
+            self.tempControl.cc.coolingTargetUpper = float(newSettings[JSONKEY_coolingTargetUpper])
+
+        if JSONKEY_coolingTargetLower in newSettings:
+            self.tempControl.cc.coolingTargetLower = float(newSettings[JSONKEY_coolingTargetLower])
+
+        if JSONKEY_maxHeatTimeForEstimate in newSettings:
+            self.tempControl.cc.maxHeatTimeForEstimate = int(newSettings[JSONKEY_maxHeatTimeForEstimate])
+
+        if JSONKEY_maxCoolTimeForEstimate in newSettings:
+            self.tempControl.cc.maxCoolTimeForEstimate = int(newSettings[JSONKEY_maxCoolTimeForEstimate])
+
+        if JSONKEY_lightAsHeater in newSettings:
+            self.tempControl.cc.lightAsHeater = int(newSettings[JSONKEY_lightAsHeater])
+
+        if JSONKEY_rotaryHalfSteps in newSettings:
+            self.tempControl.cc.rotaryHalfSteps = int(newSettings[JSONKEY_rotaryHalfSteps])
+
+        print(vars(self.tempControl.cc))
+
+    # FIXME Still to do
+    # JSON_CONVERT(JSONKEY_fridgeFastFilter, MAKE_FILTER_SETTING_TARGET(FAST, FRIDGE), applyFilterSetting),
+    # JSON_CONVERT(JSONKEY_fridgeSlowFilter, MAKE_FILTER_SETTING_TARGET(SLOW, FRIDGE), applyFilterSetting),
+    # JSON_CONVERT(JSONKEY_fridgeSlopeFilter, MAKE_FILTER_SETTING_TARGET(SLOPE, FRIDGE), applyFilterSetting),
+    # JSON_CONVERT(JSONKEY_beerFastFilter, MAKE_FILTER_SETTING_TARGET(FAST, BEER), applyFilterSetting),
+    # JSON_CONVERT(JSONKEY_beerSlowFilter, MAKE_FILTER_SETTING_TARGET(SLOW, BEER), applyFilterSetting),
+    # JSON_CONVERT(JSONKEY_beerSlopeFilter, MAKE_FILTER_SETTING_TARGET(SLOPE, BEER), applyFilterSetting)
+
+
+    # FIXME A lot of unneeded code copied from original source should be deleted
+    # static void (*ParseJsonCallback)(const char* key, const char* val, void* data);
+
+    # static void parseJson(ParseJsonCallback fn, void* data=NULL);
+
+    #	static void print(char *fmt, ...); // use when format string is stored in RAM
+    #	static void print(char c)       // inline for arduino
+    # ifdef ARDUINO
+    #         { Serial.print(c); }
+    # else
+    #        ;
+    # endif
+
+    #	static void print_P(const char *fmt, ...); // use when format string is stored in PROGMEM with PSTR("string")
+    #	static void printNewLine(void);
+
+    def printChamberCount():
+        pass
+
+    def soundAlarm(enabled):
+        pass
+
+    def printChamberInfo():
+        pass
+
+    def sendJsonPair(name, val):  # send one JSON pair with a string value as name:val,
+        pass
+
+    #	static void sendJsonPair(const char * name, char val); // send one JSON pair with a char value as name:val,
+    #	static void sendJsonPair(const char * name, uint16_t val); // send one JSON pair with a uint16_t value as name:val,
+    #	static void sendJsonPair(const char * name, uint8_t val); // send one JSON pair with a uint8_t value as name:val,
+    def sendJsonAnnotation(name, annotation):
+        pass
+
+    def sendJsonTemp(name, temp):
+        pass
+
+    def processJsonPair(key, val, pv):  # process one pair
+        pass
+
+    #	/* Prints the name part of a json name/value pair. The name must exist in PROGMEM */
+    def printJsonName(name):
+        pass
+
+    def printJsonSeparator():
+        pass
+
+    #	struct JsonOutput {
+    #		const char* key;			// JSON key
+    #		uint8_t offset;			// offset into TempControl class
+    #		uint8_t handlerOffset;		// handler index
+    #	};
+    #	typedef void (*JsonOutputHandler)(const char* key, uint8_t offset);
+    #	static void sendJsonValues(char responseType, const JsonOutput* /*PROGMEM*/ jsonOutputMap, uint8_t mapCount);
+
+
+    # handler functions for JSON output
+    def jsonOutputUint8(key, offset):
+        pass
+
+    def jsonOutputTempToString(key, offset):
+        pass
+
+    def jsonOutputFixedPointToString(key, offset):
+        pass
+
+    def jsonOutputTempDiffToString(key, offset):
+        pass
+
+    def jsonOutputChar(key, offset):
+        pass
+
+    def jsonOutputUint16(key, offset):
+        pass
+
+    #	static const JsonOutputHandler JsonOutputHandlers[];
+    #	static const JsonOutput jsonOutputCCMap[];
+    #	static const JsonOutput jsonOutputCVMap[];
+
+    # Json parsing
+
+    def setMode(self, val):
+        mode = val[0]
+        self.tempControl.setMode(mode)
+        self.printFridgeAnnotation(STR_MODE + (STR_FMT_SET_TO % val) + STR_WEB_INTERFACE)
+
+    def setBeerSetting(self, newTemp):
+        source = None
+        if (self.tempControl.cs.mode == 'p'):
+            if (self.tempControl.cs.beerSetting is not None and (abs(
+                        newTemp - self.tempControl.cs.beerSetting) > 0.2)):  # this excludes gradual updates under 0.2 degrees
+                source = STR_TEMPERATURE_PROFILE
+        else:
+            source = STR_WEB_INTERFACE
+
+        if (source):
+            self.printBeerAnnotation(STR_BEER_TEMP + (STR_FMT_SET_TO % newTemp) + source)
+
+        self.tempControl.setBeerTemp(newTemp)
+
+    def setFridgeSetting(self, newTemp):
+        if (self.tempControl.cs.mode == 'f'):
+            self.printFridgeAnnotation(STR_FRIDGE_TEMP + (STR_FMT_SET_TO % newTemp) + STR_WEB_INTERFACE)
+
+        self.tempControl.setFridgeTemp(newTemp)
+
+    def setTempFormat(self, val):
+        # Only Celsius for now
+        # TODO - Implement Fahrenheit
+
+        pass
+
+    #	typedef void (*JsonParserHandlerFn)(const char* val, void* target);
+
+    #	struct JsonParserConvert {
+    #		const char* /*PROGMEM*/ key;
+    #		void* target;
+    #		JsonParserHandlerFn fn;
+    #	};
+
+    #	static const JsonParserConvert jsonParserConverters[];

--- a/fuscus/piLink.py
+++ b/fuscus/piLink.py
@@ -28,6 +28,7 @@ import json
 import select
 import yaml  # To get around brewpi's terse JSON
 import logging
+import termios
 
 import ui
 from constants import *
@@ -48,6 +49,12 @@ class piLink:
         # use port 25518 (beer 2 5 5 18)
         os.setegid(20)
         master, slave = pty.openpty()
+
+        # Disable echoing on slave so we don't interpret status strings as commands
+        new_settings = termios.tcgetattr(slave)
+        new_settings[3] = new_settings[3] & ~termios.ECHO
+        termios.tcsetattr(slave, termios.TCSADRAIN, new_settings)
+
         port_name = os.ttyname(slave)
         os.chmod(port_name, 0o666)
 

--- a/fuscus/piLink.py
+++ b/fuscus/piLink.py
@@ -327,16 +327,17 @@ class piLink:
         # Fix up the key names that are not the same
         d[JSONKEY_tempSettingMin] = self.tempControl.temp_convert_to_external(d.pop('tempSettingMin'))
         d[JSONKEY_tempSettingMax] = self.tempControl.temp_convert_to_external(d.pop('tempSettingMax'))
-        d[JSONKEY_iMaxError] = d.pop('iMaxError')
-        d[JSONKEY_idleRangeHigh] = d.pop('idleRangeHigh')
+        d[JSONKEY_iMaxError] = self.tempControl.temp_convert_to_external(d.pop('iMaxError'), diff=True)
+        d[JSONKEY_idleRangeHigh] = self.tempControl.temp_convert_to_external(d.pop('idleRangeHigh'), diff=True)
 
-        d[JSONKEY_idleRangeLow] = d.pop('idleRangeLow')
-        d[JSONKEY_heatingTargetUpper] = d.pop('heatingTargetUpper')
-        d[JSONKEY_heatingTargetLower] = d.pop('heatingTargetLower')
-        d[JSONKEY_coolingTargetUpper] = d.pop('coolingTargetUpper')
-        d[JSONKEY_coolingTargetLower] = d.pop('coolingTargetLower')
+        d[JSONKEY_idleRangeLow] = self.tempControl.temp_convert_to_external(d.pop('idleRangeLow'), diff=True)
+        d[JSONKEY_heatingTargetUpper] = self.tempControl.temp_convert_to_external(d.pop('heatingTargetUpper'), diff=True)
+        d[JSONKEY_heatingTargetLower] = self.tempControl.temp_convert_to_external(d.pop('heatingTargetLower'), diff=True)
+        d[JSONKEY_coolingTargetUpper] = self.tempControl.temp_convert_to_external(d.pop('coolingTargetUpper'), diff=True)
+        d[JSONKEY_coolingTargetLower] = self.tempControl.temp_convert_to_external(d.pop('coolingTargetLower'), diff=True)
         d[JSONKEY_maxHeatTimeForEstimate] = d.pop('maxHeatTimeForEstimate')
         d[JSONKEY_maxCoolTimeForEstimate] = d.pop('maxCoolTimeForEstimate')
+        # TODO - Determine if the filters have units (need to be converted)
         d[JSONKEY_fridgeFastFilter] = d.pop('fridgeFastFilter')
         d[JSONKEY_fridgeSlowFilter] = d.pop('fridgeSlowFilter')
         d[JSONKEY_fridgeSlopeFilter] = d.pop('fridgeSlopeFilter')
@@ -351,9 +352,9 @@ class piLink:
     def sendControlVariables(self, cv):
         d = vars(cv).copy()
         # Fix up the key names that are not the same
-        d[JSONKEY_estimatedPeak] = d.pop('estimatedPeak')
-        d[JSONKEY_negPeakEstimate] = d.pop('negPeakEstimate')
-        d[JSONKEY_posPeakEstimate] = d.pop('posPeakEstimate')
+        d[JSONKEY_estimatedPeak] = self.tempControl.temp_convert_to_external(d.pop('estimatedPeak'))
+        d[JSONKEY_negPeakEstimate] = self.tempControl.temp_convert_to_external(d.pop('negPeakEstimate'))
+        d[JSONKEY_posPeakEstimate] = self.tempControl.temp_convert_to_external(d.pop('posPeakEstimate'))
 
         self.f.write(bytes('V:' + json.dumps(d) + '\r\n', 'UTF-8'))
 
@@ -409,11 +410,16 @@ class piLink:
         # JSON_CONVERT(JSONKEY_tempSettingMax, &tempControl.cc.tempSettingMax, setStringToTemp),
         # JSON_CONVERT(JSONKEY_pidMax, &tempControl.cc.pidMax, setStringToTempDiff),
 
+        # TODO - Check if these need to flip to use convert_to_internal
         if JSONKEY_tempSettingMin in newSettings:
             self.tempControl.cc.tempSettingMin = float(newSettings[JSONKEY_tempSettingMin])
 
         if JSONKEY_tempSettingMax in newSettings:
             self.tempControl.cc.tempSettingMax = float(newSettings[JSONKEY_tempSettingMax])
+
+        if JSONKEY_pidMax in newSettings:
+            # self.tempControl.cc.pidMax = self.tempControl.temp_convert_to_internal(float(newSettings[JSONKEY_pidMax]), diff=True)
+            pass  # Not Implemented
 
         # JSON_CONVERT(JSONKEY_Kp, &tempControl.cc.Kp, setStringToFixedPoint),
         # JSON_CONVERT(JSONKEY_Ki, &tempControl.cc.Ki, setStringToFixedPoint),
@@ -441,25 +447,25 @@ class piLink:
         # JSON_CONVERT(JSONKEY_rotaryHalfSteps, &tempControl.cc.rotaryHalfSteps, setBool),
 
         if JSONKEY_iMaxError in newSettings:
-            self.tempControl.cc.iMaxError = float(newSettings[JSONKEY_iMaxError])
+            self.tempControl.cc.iMaxError = self.tempControl.temp_convert_to_internal(float(newSettings[JSONKEY_iMaxError]), diff=True)
 
         if JSONKEY_idleRangeHigh in newSettings:
-            self.tempControl.cc.idleRangeHigh = float(newSettings[JSONKEY_idleRangeHigh])
+            self.tempControl.cc.idleRangeHigh = self.tempControl.temp_convert_to_internal(float(newSettings[JSONKEY_idleRangeHigh]), diff=True)
 
         if JSONKEY_idleRangeLow in newSettings:
-            self.tempControl.cc.idleRangeLow = float(newSettings[JSONKEY_idleRangeLow])
+            self.tempControl.cc.idleRangeLow = self.tempControl.temp_convert_to_internal(float(newSettings[JSONKEY_idleRangeLow]), diff=True)
 
         if JSONKEY_heatingTargetUpper in newSettings:
-            self.tempControl.cc.heatingTargetUpper = float(newSettings[JSONKEY_heatingTargetUpper])
+            self.tempControl.cc.heatingTargetUpper = self.tempControl.temp_convert_to_internal(float(newSettings[JSONKEY_heatingTargetUpper]), diff=True)
 
         if JSONKEY_heatingTargetLower in newSettings:
-            self.tempControl.cc.heatingTargetLower = float(newSettings[JSONKEY_heatingTargetLower])
+            self.tempControl.cc.heatingTargetLower = self.tempControl.temp_convert_to_internal(float(newSettings[JSONKEY_heatingTargetLower]), diff=True)
 
         if JSONKEY_coolingTargetUpper in newSettings:
-            self.tempControl.cc.coolingTargetUpper = float(newSettings[JSONKEY_coolingTargetUpper])
+            self.tempControl.cc.coolingTargetUpper = self.tempControl.temp_convert_to_internal(float(newSettings[JSONKEY_coolingTargetUpper]), diff=True)
 
         if JSONKEY_coolingTargetLower in newSettings:
-            self.tempControl.cc.coolingTargetLower = float(newSettings[JSONKEY_coolingTargetLower])
+            self.tempControl.cc.coolingTargetLower = self.tempControl.temp_convert_to_internal(float(newSettings[JSONKEY_coolingTargetLower]), diff=True)
 
         if JSONKEY_maxHeatTimeForEstimate in newSettings:
             self.tempControl.cc.maxHeatTimeForEstimate = int(newSettings[JSONKEY_maxHeatTimeForEstimate])

--- a/fuscus/piLink.py
+++ b/fuscus/piLink.py
@@ -29,6 +29,7 @@ import select
 import yaml  # To get around brewpi's terse JSON
 import logging
 import termios
+import datetime
 
 import ui
 from constants import *
@@ -362,12 +363,16 @@ class piLink:
 
     def receiveJson(self):  # receive settings as JSON key:value pairs
         jsonBuf = ''
-        while 1:  # FIXME Implement a one-second timeout here
-            print("Timeout needed!")
+
+        timeout_past = datetime.datetime.now() + datetime.timedelta(seconds=1)  # 1 second timeout for receive
+
+        while 1:
             inByte = self.updateBuffer()
             jsonBuf += inByte
             if inByte == '}':
                 break
+            if datetime.datetime.now() > timeout_past:  # If this takes longer than a second, something went wrong
+                return
 
         jsonBuf = jsonBuf.replace(':', ': ')  # Fixup hacked JSON so YAML can read it
 
@@ -588,7 +593,6 @@ class piLink:
     def setTempFormat(self, val):
         # Only Celsius for now
         # TODO - Implement Fahrenheit
-
         pass
 
     #	typedef void (*JsonParserHandlerFn)(const char* val, void* target);

--- a/fuscus/tempControl.py
+++ b/fuscus/tempControl.py
@@ -48,729 +48,709 @@ MIN_SWITCH_TIME = 600
 COOL_PEAK_DETECT_TIME = 1800
 HEAT_PEAK_DETECT_TIME = 900
 
-MODES = {	'MODE_FRIDGE_CONSTANT' : 'f',
-			'MODE_BEER_CONSTANT' : 'b',
-			'MODE_BEER_PROFILE' : 'p',
-			'MODE_OFF' : 'o',
-			'MODE_TEST' : 't',
-		}
+MODES = {'MODE_FRIDGE_CONSTANT': 'f',
+         'MODE_BEER_CONSTANT': 'b',
+         'MODE_BEER_PROFILE': 'p',
+         'MODE_OFF': 'o',
+         'MODE_TEST': 't',
+         }
 
-STATES = {	'IDLE' : 0,
-			'STATE_OFF' : 1,
-			'DOOR_OPEN' : 2,	# used by the Display only
-			'HEATING' : 3,
-			'COOLING' : 4,
-			'WAITING_TO_COOL' : 5,
-			'WAITING_TO_HEAT' : 6,
-			'WAITING_FOR_PEAK_DETECT' : 7,
-			'COOLING_MIN_TIME' : 8,
-			'HEATING_MIN_TIME' : 9,
-		}
+STATES = {'IDLE': 0,
+          'STATE_OFF': 1,
+          'DOOR_OPEN': 2,  # used by the Display only
+          'HEATING': 3,
+          'COOLING': 4,
+          'WAITING_TO_COOL': 5,
+          'WAITING_TO_HEAT': 6,
+          'WAITING_FOR_PEAK_DETECT': 7,
+          'COOLING_MIN_TIME': 8,
+          'HEATING_MIN_TIME': 9,
+          }
 
 
 # These two structs are stored in and loaded from EEPROM
 class ControlSettings:
-	def __init__(self):
-		self.mode = None
-		self.beerSetting = None
-		self.fridgeSetting = None
-		self.heatEstimator = None # updated automatically by self learning algorithm
-		self.coolEstimator = None # updated automatically by self learning algorithm
+    def __init__(self):
+        self.mode = None
+        self.beerSetting = None
+        self.fridgeSetting = None
+        self.heatEstimator = None  # updated automatically by self learning algorithm
+        self.coolEstimator = None  # updated automatically by self learning algorithm
+
 
 class ControlVariables:
-	def __init__(self):
-		self.beerDiff = 0
-		self.diffIntegral = 0
-		self.beerSlope = 0
-		self.p = 0
-		self.i = 0
-		self.d = 0
-		self.estimatedPeak = 0
-		self.negPeakEstimate = 0	# last estimate
-		self.posPeakEstimate = 0
-		self.negPeak = 0	# last detected peak
-		self.posPeak = 0
+    def __init__(self):
+        self.beerDiff = 0
+        self.diffIntegral = 0
+        self.beerSlope = 0
+        self.p = 0
+        self.i = 0
+        self.d = 0
+        self.estimatedPeak = 0
+        self.negPeakEstimate = 0  # last estimate
+        self.posPeakEstimate = 0
+        self.negPeak = 0  # last detected peak
+        self.posPeak = 0
+
 
 class ControlConstants:
-	def __init__(self):
-		self.tempFormat = None
-		self.tempSettingMin = None
-		self.tempSettingMax = None
-		self.Kp = None
-		self.Ki = None
-		self.Kd = None
-		self.iMaxError = None
-		self.idleRangeHigh = None
-		self.idleRangeLow = None
-		self.heatingTargetUpper = None
-		self.heatingTargetLower = None
-		self.coolingTargetUpper = None
-		self.coolingTargetLower = None
-		self.maxHeatTimeForEstimate = None	# max time for heat estimate in seconds
-		self.maxCoolTimeForEstimate = None	# max time for heat estimate in seconds
-		# for the filter coefficients the b value is stored. a is calculated from b.
-		self.fridgeFastFilter = None	# for display, logging and on-off control
-		self.fridgeSlowFilter = None	# for peak detection
-		self.fridgeSlopeFilter = None	# not used in current control algorithm
-		self.beerFastFilter = None	# for display and logging
-		self.beerSlowFilter = None	# for on/off control algorithm
-		self.beerSlopeFilter = None	# for PID calculation
-		self.lightAsHeater = None		# use the light to heat rather than the configured heater device
-		self.rotaryHalfSteps = None	# define whether to use full or half steps for the rotary encoder
-		self.pidMax = None
+    def __init__(self):
+        self.tempFormat = None
+        self.tempSettingMin = None
+        self.tempSettingMax = None
+        self.Kp = None
+        self.Ki = None
+        self.Kd = None
+        self.iMaxError = None
+        self.idleRangeHigh = None
+        self.idleRangeLow = None
+        self.heatingTargetUpper = None
+        self.heatingTargetLower = None
+        self.coolingTargetUpper = None
+        self.coolingTargetLower = None
+        self.maxHeatTimeForEstimate = None  # max time for heat estimate in seconds
+        self.maxCoolTimeForEstimate = None  # max time for heat estimate in seconds
+        # for the filter coefficients the b value is stored. a is calculated from b.
+        self.fridgeFastFilter = None  # for display, logging and on-off control
+        self.fridgeSlowFilter = None  # for peak detection
+        self.fridgeSlopeFilter = None  # not used in current control algorithm
+        self.beerFastFilter = None  # for display and logging
+        self.beerSlowFilter = None  # for on/off control algorithm
+        self.beerSlopeFilter = None  # for PID calculation
+        self.lightAsHeater = None  # use the light to heat rather than the configured heater device
+        self.rotaryHalfSteps = None  # define whether to use full or half steps for the rotary encoder
+        self.pidMax = None
 
 
 class tempController:
-	
-	def __init__(self, ID_fridge, ID_beer=None, ID_ambient=None,
-				cooler=None, heater=None, door=None):
-		# We must have at least a fridge sensor
-		
-		self.cs = ControlSettings()
-		self.cv = ControlVariables()
-		self.cc = ControlConstants()
-		
-		# State variables
-		self.state = STATES['IDLE']
-		self.cs.mode = MODES['MODE_OFF']
-
-		self.doPosPeakDetect = None
-		self.doNegPeakDetect = None
-		
-		self.door = door
-		self.doorOpen = None
-
-		self.cooler = cooler
-		self.heater = heater
-		self.light = None	# Not implemented
-		self.fan = None		# Not implemented
-		
-		self.lastIdleTime = ticks.seconds()
-		self.waitTime = None
-		
-		self.storedBeerSetting = None
-
-		#cameraLight.setActive(false);
-	
-		#this is for cases where the device manager hasn't configured beer/fridge sensor.
-		#if (self.beerSensor==None):
-		self.beerSensor = tempSensor.sensor(ID_beer)
-
-		#if (self.fridgeSensor==None):
-		self.fridgeSensor = tempSensor.sensor(ID_fridge)
-	
-		self.ambientSensor = tempSensor.sensor(ID_ambient)
-		
-		self.beerSensor.init()
-		self.fridgeSensor.init()
-		self.ambientSensor.init()
-
-		self.updateTemperatures()
-		self.reset()
-	
-		# Do not allow heating/cooling directly after reset.
-		# A failing script + CRON + Arduino uno (which resets on serial
-		# connect) could damage the compressor
-		# For test purposes, set these to -3600 to eliminate waiting
-		# after reset
-		self.lastHeatTime = ticks.seconds()
-		self.lastCoolTime = ticks.seconds()
-		
-		self.integralUpdateCounter = 0
-
-		# piLink will insert a reference to itself as self.piLink here
-
-
-	def reset(self):
-		self.doPosPeakDetect = False
-		self.doNegPeakDetect = False
-
-
-	def updateSensor(self, sensor):
-		sensor.update()
-		#if not (sensor.isConnected()):
-		#	sensor.init();
-
-
-	def updateTemperatures(self):
-		self.updateSensor(self.beerSensor)
-		self.updateSensor(self.fridgeSensor)
-	
-		# Read ambient sensor to keep the value up to date.
-		# If no sensor is connected, this does nothing.
-		# This prevents a delay in serial response because
-		# the value is not up to date.
-		#if(ambientSensor->read() == TEMP_SENSOR_DISCONNECTED){
-		#ambientSensor->init(); # try to reconnect a disconnected, but installed sensor
-		self.updateSensor(self.ambientSensor)
-
-	
-	def modeIsBeer(self):
-		return self.cs.mode in (MODES['MODE_BEER_CONSTANT'],
-						  MODES['MODE_BEER_PROFILE'])
-
-
-	def updatePID(self):
-		#static unsigned char integralUpdateCounter = 0;
-		if (self.modeIsBeer()):
-			print ("Mode is beer")
-			#if(isDisabledOrInvalid(cs.beerSetting)){
-			if (self.cs.beerSetting is None):
-				print ("beerSetting is None")
-				# beer setting is not updated yet
-				# set fridge to unknown too
-				self.cs.fridgeSetting = None
-				return
-
-			# fridge setting is calculated with PID algorithm.
-			# Beer temperature error is input to PID
-			self.cv.beerDiff = self.cs.beerSetting - self.beerSensor.readSlowFiltered()
-			self.cv.beerSlope = self.beerSensor.readSlope()
-			fridgeFastFiltered = self.fridgeSensor.readFastFiltered()
-
-			self.integralUpdateCounter += 1
-			
-			print ("integralUpdateCounter %s"%self.integralUpdateCounter)
-
-			if (self.integralUpdateCounter == 60):
-				self.integralUpdateCounter = 0
-				integratorUpdate = self.cv.beerDiff
-				# Only update integrator in IDLE, because that's when the
-				# fridge temp has reached the fridge setting.
-				# If the beer temp is still not correct, the fridge setting
-				# is too low/high and integrator action is needed.
-				if (self.state != STATES['IDLE']):
-					integratorUpdate = 0
-
-				elif (abs(integratorUpdate) < self.cc.iMaxError):
-					# difference is smaller than iMaxError
-					# check additional conditions to see if integrator
-					# should be active to prevent windup
-					updateSign = bool(integratorUpdate > 0)	# True = positive, False = negative
-					integratorSign = bool(self.cv.diffIntegral > 0)
-					if (updateSign == integratorSign):
-						# beerDiff and integrator have same sign. Integrator would be increased.
-						# If actuator is already at max increasing actuator will only cause integrator windup.
-						if (self.cs.fridgeSetting >= self.cc.tempSettingMax):
-							integratorUpdate = 0
-						if (self.cs.fridgeSetting <= self.cc.tempSettingMin):
-							integratorUpdate = 0
-						if ((self.cs.fridgeSetting - self.cs.beerSetting) >= self.cc.pidMax):
-							integratorUpdate = 0
-						if ((self.cs.beerSetting - self.cs.fridgeSetting) >= self.cc.pidMax):
-							integratorUpdate = 0
-						# cooling and fridge temp is more than 2 degrees from setting, actuator is saturated. (Note: 1024 is 2 << 9)
-						if (not updateSign and (fridgeFastFiltered > (self.cs.fridgeSetting + 2))): # was  +1024))):
-							integratorUpdate = 0
-						# heating and fridge temp is more than 2 degrees from setting, actuator is saturated.
-						if (updateSign and (fridgeFastFiltered < (self.cs.fridgeSetting - 2))): # was -1024))):
-							integratorUpdate = 0
-					else:
-						# integrator action is decreased. Decrease faster than increase.
-						integratorUpdate *= 2
-				else:
-					# decrease integral by 1/8 when far from the end value to reset the integrator
-					integratorUpdate = -(self.cv.diffIntegral / 8)
-
-				self.cv.diffIntegral += integratorUpdate
-
-			# calculate PID parts.
-			print(vars(self.cc))
-			print(vars(self.cv))
-			self.cv.p = self.cc.Kp * self.cv.beerDiff
-			self.cv.i = self.cc.Ki * self.cv.diffIntegral
-			self.cv.d = self.cc.Kd * self.cv.beerSlope
-			newFridgeSetting = self.cs.beerSetting
-			newFridgeSetting += self.cv.p
-			newFridgeSetting += self.cv.i
-			newFridgeSetting += self.cv.d
-			# constrain to tempSettingMin or beerSetting - pidMAx, whichever is lower.
-			lowerBound = self.cc.tempSettingMin if (self.cs.beerSetting <= self.cc.tempSettingMin + self.cc.pidMax) else (self.cs.beerSetting - self.cc.pidMax)
-			# constrain to tempSettingMax or beerSetting + pidMAx, whichever is higher.
-			upperBound = self.cc.tempSettingMax if (self.cs.beerSetting >= self.cc.tempSettingMax - self.cc.pidMax) else (self.cs.beerSetting + self.cc.pidMax)
-			#cs.fridgeSetting = constrain(constrainTemp16(newFridgeSetting), lowerBound, upperBound);
-			self.cs.fridgeSetting = max(lowerBound, min(newFridgeSetting, upperBound))
-
-		elif (self.cs.mode == MODES['MODE_FRIDGE_CONSTANT']):
-			# FridgeTemperature is set manually, disable beer setpoint
-			self.cs.beerSetting = None	#DISABLED_TEMP;
-
-
-	def updateState(self):
-
-		print("Update state. Mode %s, state %s"%
-			({v: k for k, v in MODES.items()}[self.cs.mode],
-			{v: k for k, v in STATES.items()}[self.state]))
-
-		stayIdle = False
-		newDoorOpen = self.door.isOpen
-
-		if (newDoorOpen != self.doorOpen):
-			self.doorOpen = newDoorOpen
-			print("Fridge door %s"%('opened' if self.doorOpen else 'closed'))
-			self.piLink.printFridgeAnnotation("Fridge door %s"%
-									 ("opened" if self.doorOpen  else "closed"))
-
-		if (self.cs.mode == MODES['MODE_OFF']):
-			self.state = STATES['STATE_OFF']
-			stayIdle = True
-
-		# stay idle when one of the required sensors is disconnected,
-		# or the fridge setting is INVALID_TEMP
-		#FIXME: if(isDisabledOrInvalid(cs.fridgeSetting) ||
-		#!fridgeSensor->isConnected() ||
-		#(!beerSensor->isConnected() && tempControl.modeIsBeer())):
-		#	self.state = 'IDLE'
-		#	stayIdle = True
-
-		sinceIdle = self.timeSinceIdle()
-		sinceCooling = self.timeSinceCooling()
-		sinceHeating = self.timeSinceHeating()
-		fridgeFast = self.fridgeSensor.readFastFiltered()
-		beerFast = self.beerSensor.readFastFiltered()
-		secs = ticks.seconds()
-
-		if self.state in (STATES['IDLE'], STATES['STATE_OFF'],
-			STATES['WAITING_TO_COOL'], STATES['WAITING_TO_HEAT'],
-			STATES['WAITING_FOR_PEAK_DETECT']):
-			self.lastIdleTime = secs
-			if not stayIdle:
-				# set waitTime to zero. It will be set to the maximum
-				# required waitTime below when wait is in effect.
-				#if(stayIdle):
-				#	break
-				self.resetWaitTime()
-				if (fridgeFast > (self.cs.fridgeSetting+self.cc.idleRangeHigh) ):	# fridge temperature is too high
-					self.updateWaitTime(MIN_SWITCH_TIME, sinceHeating)
-					if (self.cs.mode == MODES['MODE_FRIDGE_CONSTANT']):
-						self.updateWaitTime(MIN_COOL_OFF_TIME_FRIDGE_CONSTANT, sinceCooling)
-					else:
-						if (beerFast < (self.cs.beerSetting + 0.03125) ): #+ 16) ):	# If beer is already under target, stay/go to idle. 1/2 sensor bit idle zone
-							self.state = STATES['IDLE']	# beer is already colder than setting, stay in or go to idle
-							#break # FIXME: We need to skip the next if statement
-						else:
-							self.updateWaitTime(MIN_COOL_OFF_TIME, sinceCooling)
-					if (self.cooler != None): # FIXME was &defaultActuator):
-						if (self.getWaitTime() > 0):
-							self.state = STATES['WAITING_TO_COOL']
-						else:
-							self.state = STATES['COOLING']
-				elif (fridgeFast < (self.cs.fridgeSetting + self.cc.idleRangeLow)):	# fridge temperature is too low
-					print("Fridge temperature is too low")
-					self.updateWaitTime(MIN_SWITCH_TIME, sinceCooling)
-					self.updateWaitTime(MIN_HEAT_OFF_TIME, sinceHeating)
-					if (self.cs.mode != MODES['MODE_FRIDGE_CONSTANT']):
-						if (beerFast > (self.cs.beerSetting - 0.03125) ): # - 16)){ // If beer is already over target, stay/go to idle. 1/2 sensor bit idle zone
-							self.state = STATES['IDLE']	# beer is already warmer than setting, stay in or go to idle
-							#break # FIXME: We need to skip the next if statement
-					#if(self.heater != &defaultActuator or (self.lightAsHeater and (self.light != &defaultActuator))):
-					# FIXME what is &defaultActuator ?
-					if ((self.heater != None or
-						(self.cc.lightAsHeater and (self.light != None)))):
-						if (self.getWaitTime() > 0):
-							self.state = STATES['WAITING_TO_HEAT']
-						else:
-							self.state = STATES['HEATING']
-				else:
-					self.state = STATES['IDLE']	# within IDLE range, always go to IDLE
-					#break
-			
-			if (self.state == STATES['HEATING']
-				or self.state == STATES['COOLING']):
-				# If peak detect is not finished, but the fridge wants to switch to heat/cool
-				# Wait for peak detection and show on display
-				if self.doNegPeakDetect:
-					self.updateWaitTime(COOL_PEAK_DETECT_TIME, sinceCooling)
-					self.state = STATES['WAITING_FOR_PEAK_DETECT']
-				elif self.doPosPeakDetect:
-					self.updateWaitTime(HEAT_PEAK_DETECT_TIME, sinceHeating)
-					self.state = STATES['WAITING_FOR_PEAK_DETECT']
-
-		elif self.state in (STATES['COOLING'], STATES['COOLING_MIN_TIME']):
-			self.doNegPeakDetect = True
-			self.lastCoolTime = secs
-			self.updateEstimatedPeak(self.cc.maxCoolTimeForEstimate, self.cs.coolEstimator, sinceIdle)
-			self.state = STATES['COOLING']	# set to cooling here, so the display of COOLING/COOLING_MIN_TIME is correct
-			# stop cooling when estimated fridge temp peak lands on target or if beer is already too cold (1/2 sensor bit idle zone)
-			if (self.cv.estimatedPeak <= self.cs.fridgeSetting
-				or (self.cs.mode != MODES['MODE_FRIDGE_CONSTANT']
-				and beerFast < (self.cs.beerSetting - 0.03125))):
-				if (sinceIdle > MIN_COOL_ON_TIME):
-					self.cv.negPeakEstimate = self.cv.estimatedPeak	# remember estimated peak when I switch to IDLE, to adjust estimator later
-					self.state = STATES['IDLE']
-					#break
-				else:
-					self.state = STATES['COOLING_MIN_TIME']
-					#break
-
-		elif self.state in (STATES['HEATING'], STATES['HEATING_MIN_TIME']):
-			self.doPosPeakDetect = True
-			self.lastHeatTime = secs
-			self.updateEstimatedPeak(self.cc.maxHeatTimeForEstimate, self.cs.heatEstimator, sinceIdle)
-			self.state = STATES['HEATING']	# reset to heating here, so the display of HEATING/HEATING_MIN_TIME is correct
-			# stop heating when estimated fridge temp peak lands on target or if beer is already too warm (1/2 sensor bit idle zone)
-			if (self.cv.estimatedPeak >= self.cs.fridgeSetting
-				or (self.cs.mode != MODES['MODE_FRIDGE_CONSTANT']
-				and beerFast > (self.cs.beerSetting + 0.03125))):
-				if (sinceIdle > MIN_HEAT_ON_TIME):
-					self.cv.posPeakEstimate = self.cv.estimatedPeak	# remember estimated peak when I switch to IDLE, to adjust estimator later
-					self.state = STATES['IDLE']
-					#break
-				else:
-					self.state = STATES['HEATING_MIN_TIME']
-					#break
-
-		elif self.state in (STATES['DOOR_OPEN']):
-			pass	# do nothing
-		else:
-			logging.debug("Unknown state in updatePID: %s"%self.state)
-
-
-	def updateEstimatedPeak(self, timeLimit, estimator, sinceIdle):
-		activeTime = min(timeLimit, sinceIdle)	# heat or cool time in seconds
-		estimatedOvershoot = (estimator * activeTime) / 3600	# overshoot estimator is in overshoot per hour
-		if (self.stateIsCooling()):
-			estimatedOvershoot = -estimatedOvershoot	# when cooling subtract overshoot from fridge temperature	
-		self.cv.estimatedPeak = self.fridgeSensor.readFastFiltered() + estimatedOvershoot
-
-
-	def updateOutputs(self):
-		if (self.cs.mode == MODES['MODE_TEST']):
-			return
-		#cameraLight.update();
-		heating = self.stateIsHeating()
-		cooling = self.stateIsCooling()
-		self.cooler.set_output(cooling)
-		self.heater.set_output(heating)
-		#light->setActive(isDoorOpen() || (cc.lightAsHeater && heating) || cameraLightState.isActive());	
-		#fan->setActive(heating || cooling);
-
-
-	def detectPeaks(self):
-		"""Detect peaks in fridge temperature to tune overshoot estimators."""
-		#LOG_ID_TYPE detected = 0;
-		detected = None
-		peak = estimate = error = oldEstimator = newEstimator = None
-		if (self.doPosPeakDetect and not self.stateIsHeating()):
-			# FIXME: Either of these could be None.  Used to be INVALID_TEMP, so the maths would work.
-			# INVALID_TEMP = -32768
-			# error = peak - estimate
-			# peak is invalid, error is very -ve
-			# estimate is invalid, error 
-			
-			peak = self.fridgeSensor.detectPosPeak()
-			estimate = self.cv.posPeakEstimate
-			#if peak is not None:	# FIXME: This could be moved into if statement below
-			#	error = peak - estimate
-			oldEstimator = self.cs.heatEstimator
-			if peak is not None:	#INVALID_TEMP):
-				# positive peak detected
-				error = peak - estimate
-				if (error > self.cc.heatingTargetUpper):
-					# Peak temperature was higher than the estimate.
-					# Overshoot was higher than expected
-					# Increase estimator to increase the estimated overshoot
-					self.increaseEstimator(self.cs.heatEstimator, error)
-					
-				if (error < self.cc.heatingTargetLower):
-					# Peak temperature was lower than the estimate.
-					# Overshoot was lower than expected
-					# Decrease estimator to decrease the estimated overshoot
-					self.decreaseEstimator(self.cs.heatEstimator, error)
-
-				detected = 'INFO_POSITIVE_PEAK'
-
-			elif (self.timeSinceHeating() > HEAT_PEAK_DETECT_TIME):
-				if (self.fridgeSensor.readFastFiltered()
-					< (self.cv.posPeakEstimate + self.cc.heatingTargetLower)):
-					# Idle period almost reaches maximum allowed time for peak detection
-					# This is the heat, then drift up too slow (but in the right direction).
-					# estimator is too high
-					peak = self.fridgeSensor.readFastFiltered()
-					self.decreaseEstimator(self.cs.heatEstimator, error)
-					detected = 'INFO_POSITIVE_DRIFT'
-
-				else:
-					# maximum time for peak estimation reached
-					self.doPosPeakDetect = False
-
-			if detected:
-				newEstimator = self.cs.heatEstimator
-				self.cv.posPeak = peak
-				self.doPosPeakDetect = False
-			
-		elif (self.doNegPeakDetect and not self.stateIsCooling()):
-			# FIXME: Either of these could be None.  Used to be INVALID_TEMP, so the maths would work.
-			peak = self.fridgeSensor.detectNegPeak()
-			estimate = self.cv.negPeakEstimate
-			print("peak %s : estimate %s"%(peak, estimate))
-			#if peak is not None:	# FIXME: This could be moved into if statement below
-			#	error = peak - estimate	# FIXME: Crash if estimate is None
-			oldEstimator = self.cs.coolEstimator
-			if (peak != None):	#INVALID_TEMP):
-				# negative peak detected
-				error = peak - estimate	# FIXME: Crash if estimate is None
-				if (error < self.cc.coolingTargetLower):
-					# Peak temperature was lower than the estimate.
-					# Overshoot was higher than expected
-					# Increase estimator to increase the estimated overshoot
-					self.increaseEstimator(self.cs.coolEstimator, error)
-				if (error > self.cc.coolingTargetUpper):
-					# Peak temperature was higher than the estimate.
-					# Overshoot was lower than expected
-					# Decrease estimator to decrease the estimated overshoot
-					self.decreaseEstimator(self.cs.coolEstimator, error)
-
-				detected = 'INFO_NEGATIVE_PEAK'
-			
-			elif (self.timeSinceCooling() > COOL_PEAK_DETECT_TIME):
-				if (self.fridgeSensor.readFastFiltered()
-					> (self.cv.negPeakEstimate + self.cc.coolingTargetUpper)):
-					# Idle period almost reaches maximum allowed time for peak detection
-					# This is the cooling, then drift down too slow (but in the right direction).
-					# estimator is too high
-					peak = self.fridgeSensor.readFastFiltered()
-					self.decreaseEstimator(self.cs.coolEstimator, error)	# FIXME: error is not known here
-					detected = 'INFO_NEGATIVE_DRIFT'
-				else:
-					# maximum time for peak estimation reached
-					self.doNegPeakDetect = False
-
-			if detected:
-				newEstimator = self.cs.coolEstimator
-				self.cv.negPeak = peak
-				self.doNegPeakDetect = False
-			
-		if detected:
-			# send out log message for type of peak detected
-			#logInfoTempTempFixedFixed(detected, peak, estimate, oldEstimator, newEstimator)
-			logging.info("Peak detected: %s %s %s %s %s"%(detected, peak, estimate, oldEstimator, newEstimator))
-
-
-	def increaseEstimator(self, estimator, error):
-		"""Increase estimator at least 20%, max 50%."""
-		#temperature factor = 614 + constrainTemp(abs(error)>>5, 0, 154);
-		#// 1.2 + 3.1% of error, limit between 1.2 and 1.5
-		factor = 1.2 + max(0, min(abs(error) * 0.031, 0.3))	# 1.2 + 3.1% of error, limit between 1.2 and 1.5
-		estimator *= factor
-		if (estimator < 0.05):
-			estimator = 0.05	# make estimator at least 0.05
-		# FIXME: eepromManager.storeTempSettings();
-
-
-	def decreaseEstimator(self, estimator, error):
-		"""Decrease estimator at least 16.7% (1/1.2), max 33.3% (1/1.5)."""
-		#temperature factor = 426 - constrainTemp(abs(error)>>5, 0, 85);
-		#// 0.833 - 3.1% of error, limit between 0.667 and 0.833
-		factor = 0.833 - max(0, min(abs(error) * 0.031, 0.166))	# 0.833 - 3.1% of error, limit between 0.667 and 0.833
-		estimator *= factor
-		# FIXME: eepromManager.storeTempSettings();
-
-
-	def timeSinceCooling(self):
-		return ticks.timeSince(self.lastCoolTime)
-
-	
-	def timeSinceHeating(self):
-		return ticks.timeSince(self.lastHeatTime)
-
-
-	def timeSinceIdle(self):
-		return ticks.timeSince(self.lastIdleTime)
-
-
-	def loadDefaultSettings(self):
-		#if BREWPI_EMULATE
-		#	setMode(MODE_BEER_CONSTANT);
-		#else	
-		#	setMode(MODE_OFF);
-		#endif
-		self.setMode(MODES['MODE_OFF'])
-		self.cs.beerSetting = None	# start with no temp settings
-		self.cs.fridgeSetting = None
-		self.cs.heatEstimator = 0.2 # intToTempDiff(2)/10; // 0.2
-		self.cs.coolEstimator = 5 #intToTempDiff(5);
-
-
-	def storeConstants(self):
-		"""Write variables in cc class to EEPROM (file)."""
-		with open('EEPROM.cc', 'wb') as f:
-			pickle.dump(vars(self.cc), f, pickle.HIGHEST_PROTOCOL)
-
-
-	def loadConstants(self):
-		"""Read variables in cc class from EEPROM (file)."""
-		with open('EEPROM.cc', 'rb') as f:
-			data = pickle.load(f)
-		
-		self.cc.__dict__.update(data)
-
-		self.initFilters()
-
-
-	def storeSettings(self):
-		"""Write variables in cs class to EEPROM (file)."""
-		with open('EEPROM.cs', 'wb') as f:
-			pickle.dump(vars(self.cs), f, pickle.HIGHEST_PROTOCOL)
-		self.storedBeerSetting = self.cs.beerSetting
-
-
-	def loadSettings(self):
-		"""Read variables in cs class from EEPROM (file)."""
-		with open('EEPROM.cs', 'rb') as f:
-			data = pickle.load(f)
-		
-		self.cs.__dict__.update(data)
-
-		logging.debug("loaded settings")
-		self.storedBeerSetting = self.cs.beerSetting
-		self.setMode(self.cs.mode, True)	# Force the mode update
-
-	
-	def loadDefaultConstants(self):
-		# See ControlConstants class definition for descriptions
-		self.cc.tempFormat = 'C'
-		self.cc.tempSettingMin = 1
-		self.cc.tempSettingMax = 30
-		self.cc.Kp = 5.0
-		self.cc.Ki = 0.35
-		self.cc.Kd = 2.5
-		self.cc.iMaxError = 0.5
-		self.cc.idleRangeHigh = 1
-		self.cc.idleRangeLow = -1
-		self.cc.heatingTargetUpper = 0.3
-		self.cc.heatingTargetLower = -0.2
-		self.cc.coolingTargetUpper = 0.2
-		self.cc.coolingTargetLower = -0.3
-		self.cc.maxHeatTimeForEstimate = 600
-		self.cc.maxCoolTimeForEstimate = 1200
-		self.cc.fridgeFastFilter = 1
-		self.cc.fridgeSlowFilter = 4
-		self.cc.fridgeSlopeFilter = 3
-		self.cc.beerFastFilter = 3
-		self.cc.beerSlowFilter = 4
-		self.cc.beerSlopeFilter = 4
-		self.cc.lightAsHeater = 0
-		self.cc.rotaryHalfSteps = 0
-		self.cc.pidMax = 10
-
-		self.initFilters()
-
-	
-	def initFilters(self):
-		self.fridgeSensor.setFastFilterCoefficients(self.cc.fridgeFastFilter)
-		self.fridgeSensor.setSlowFilterCoefficients(self.cc.fridgeSlowFilter)
-		self.fridgeSensor.setSlopeFilterCoefficients(self.cc.fridgeSlopeFilter)
-		self.beerSensor.setFastFilterCoefficients(self.cc.beerFastFilter)
-		self.beerSensor.setSlowFilterCoefficients(self.cc.beerSlowFilter)
-		self.beerSensor.setSlopeFilterCoefficients(self.cc.beerSlopeFilter)
-
-	
-	def setMode(self, newMode, force=False):
-		logging.debug("TempControl::setMode from %s to %s", self.cs.mode, newMode)
-	
-		if (newMode != self.cs.mode or self.state == STATES['WAITING_TO_HEAT']
-			or self.state == STATES['WAITING_TO_COOL']
-			or self.state == STATES['WAITING_FOR_PEAK_DETECT']):
-			self.state = STATES['IDLE']
-			force = True
-
-		if (force):
-			self.cs.mode = newMode
-			if (newMode == MODES['MODE_OFF']):
-				self.cs.beerSetting = None
-				self.cs.fridgeSetting = None
-			
-			# FIXME: eepromManager.storeTempSettings()
-
-
-	def getBeerTemp(self):
-		if (self.beerSensor.isConnected()):
-			return self.beerSensor.readFastFiltered()
-		else:
-			return None	
-
-	
-	def	getBeerSetting(self):
-		return self.cs.beerSetting
-	
-	
-	def getFridgeTemp(self):
-		if (self.fridgeSensor.isConnected()):
-			return self.fridgeSensor.readFastFiltered()
-		else:
-			return None
-
-
-	def	getFridgeSetting(self):
-		return self.cs.fridgeSetting
-
-
-	def setBeerTemp(self, newTemp):
-		oldBeerSetting = self.cs.beerSetting
-		self.cs.beerSetting = newTemp
-		if (oldBeerSetting is None or (abs(oldBeerSetting - newTemp) > 0.5)):	# more than half degree C difference with old setting
-			self.reset()	# reset controller
-		self.updatePID()
-		self.updateState()
-		#FIXME: Implement this
-		#if (self.cs.mode != MODES['MODE_BEER_PROFILE']
-		#	or abs(self.storedBeerSetting - newTemp) > 0.25):
-			# more than 1/4 degree C difference with EEPROM
-			# Do not store settings every time in profile mode, because EEPROM has limited number of write cycles.
-			# A temperature ramp would cause a lot of writes
-			# If Raspberry Pi is connected, it will update the settings anyway. This is just a safety feature.
-			# FIXME: eepromManager.storeTempSettings()
-
-	
-	def setFridgeTemp(self, newTemp):
-		self.cs.fridgeSetting = newTemp
-		self.reset()	# reset peak detection and PID
-		self.updatePID()
-		self.updateState()
-		# FIXME eepromManager.storeTempSettings()
-
-
-	def stateIsCooling(self):
-		return self.state in (STATES['COOLING'], 
-						STATES['COOLING_MIN_TIME'])
-	
-	
-	def stateIsHeating(self):
-		return self.state in (STATES['HEATING'],
-						STATES['HEATING_MIN_TIME'])
-
-
-	def getRoomTemp(self):
-		return self.ambientSensor.temperature
-
-
-	def getMode(self):
-		return self.cs.mode
-
-
-	def getState(self):
-		return self.state
-
-
-	def getWaitTime(self):
-		return self.waitTime
-	
-	
-	def resetWaitTime(self):
-		self.waitTime = 0
-		
-		
-	def updateWaitTime(self, newTimeLimit, newTimeSince):
-		if (newTimeSince<newTimeLimit):
-			self.newWaitTime = newTimeLimit - newTimeSince
-			if (self.newWaitTime > self.waitTime):
-				self.waitTime = self.newWaitTime
-
-
-	def isDoorOpen(self):
-		return self.doorOpen
-
-	
-	def getDisplayState(self):
-		return STATES['DOOR_OPEN'] if self.isDoorOpen() else self.getState()
+    def __init__(self, ID_fridge, ID_beer=None, ID_ambient=None,
+                 cooler=None, heater=None, door=None):
+        # We must have at least a fridge sensor
+
+        self.cs = ControlSettings()
+        self.cv = ControlVariables()
+        self.cc = ControlConstants()
+
+        # State variables
+        self.state = STATES['IDLE']
+        self.cs.mode = MODES['MODE_OFF']
+
+        self.doPosPeakDetect = None
+        self.doNegPeakDetect = None
+
+        self.door = door
+        self.doorOpen = None
+
+        self.cooler = cooler
+        self.heater = heater
+        self.light = None  # Not implemented
+        self.fan = None  # Not implemented
+
+        self.lastIdleTime = ticks.seconds()
+        self.waitTime = None
+
+        self.storedBeerSetting = None
+
+        # cameraLight.setActive(false);
+
+        # this is for cases where the device manager hasn't configured beer/fridge sensor.
+        # if (self.beerSensor==None):
+        self.beerSensor = tempSensor.sensor(ID_beer)
+
+        # if (self.fridgeSensor==None):
+        self.fridgeSensor = tempSensor.sensor(ID_fridge)
+
+        self.ambientSensor = tempSensor.sensor(ID_ambient)
+
+        self.beerSensor.init()
+        self.fridgeSensor.init()
+        self.ambientSensor.init()
+
+        self.updateTemperatures()
+        self.reset()
+
+        # Do not allow heating/cooling directly after reset.
+        # A failing script + CRON + Arduino uno (which resets on serial
+        # connect) could damage the compressor
+        # For test purposes, set these to -3600 to eliminate waiting
+        # after reset
+        self.lastHeatTime = ticks.seconds()
+        self.lastCoolTime = ticks.seconds()
+
+        self.integralUpdateCounter = 0
+
+    # piLink will insert a reference to itself as self.piLink here
+
+
+    def reset(self):
+        self.doPosPeakDetect = False
+        self.doNegPeakDetect = False
+
+    def updateSensor(self, sensor):
+        sensor.update()
+
+    # if not (sensor.isConnected()):
+    #	sensor.init();
+
+
+    def updateTemperatures(self):
+        self.updateSensor(self.beerSensor)
+        self.updateSensor(self.fridgeSensor)
+
+        # Read ambient sensor to keep the value up to date.
+        # If no sensor is connected, this does nothing.
+        # This prevents a delay in serial response because
+        # the value is not up to date.
+        # if(ambientSensor->read() == TEMP_SENSOR_DISCONNECTED){
+        # ambientSensor->init(); # try to reconnect a disconnected, but installed sensor
+        self.updateSensor(self.ambientSensor)
+
+    def modeIsBeer(self):
+        return self.cs.mode in (MODES['MODE_BEER_CONSTANT'],
+                                MODES['MODE_BEER_PROFILE'])
+
+    def updatePID(self):
+        # static unsigned char integralUpdateCounter = 0;
+        if (self.modeIsBeer()):
+            print("Mode is beer")
+            # if(isDisabledOrInvalid(cs.beerSetting)){
+            if (self.cs.beerSetting is None):
+                print("beerSetting is None")
+                # beer setting is not updated yet
+                # set fridge to unknown too
+                self.cs.fridgeSetting = None
+                return
+
+            # fridge setting is calculated with PID algorithm.
+            # Beer temperature error is input to PID
+            self.cv.beerDiff = self.cs.beerSetting - self.beerSensor.readSlowFiltered()
+            self.cv.beerSlope = self.beerSensor.readSlope()
+            fridgeFastFiltered = self.fridgeSensor.readFastFiltered()
+
+            self.integralUpdateCounter += 1
+
+            print("integralUpdateCounter %s" % self.integralUpdateCounter)
+
+            if (self.integralUpdateCounter == 60):
+                self.integralUpdateCounter = 0
+                integratorUpdate = self.cv.beerDiff
+                # Only update integrator in IDLE, because that's when the
+                # fridge temp has reached the fridge setting.
+                # If the beer temp is still not correct, the fridge setting
+                # is too low/high and integrator action is needed.
+                if (self.state != STATES['IDLE']):
+                    integratorUpdate = 0
+
+                elif (abs(integratorUpdate) < self.cc.iMaxError):
+                    # difference is smaller than iMaxError
+                    # check additional conditions to see if integrator
+                    # should be active to prevent windup
+                    updateSign = bool(integratorUpdate > 0)  # True = positive, False = negative
+                    integratorSign = bool(self.cv.diffIntegral > 0)
+                    if (updateSign == integratorSign):
+                        # beerDiff and integrator have same sign. Integrator would be increased.
+                        # If actuator is already at max increasing actuator will only cause integrator windup.
+                        if (self.cs.fridgeSetting >= self.cc.tempSettingMax):
+                            integratorUpdate = 0
+                        if (self.cs.fridgeSetting <= self.cc.tempSettingMin):
+                            integratorUpdate = 0
+                        if ((self.cs.fridgeSetting - self.cs.beerSetting) >= self.cc.pidMax):
+                            integratorUpdate = 0
+                        if ((self.cs.beerSetting - self.cs.fridgeSetting) >= self.cc.pidMax):
+                            integratorUpdate = 0
+                        # cooling and fridge temp is more than 2 degrees from setting, actuator is saturated. (Note: 1024 is 2 << 9)
+                        if (not updateSign and (fridgeFastFiltered > (self.cs.fridgeSetting + 2))):  # was  +1024))):
+                            integratorUpdate = 0
+                        # heating and fridge temp is more than 2 degrees from setting, actuator is saturated.
+                        if (updateSign and (fridgeFastFiltered < (self.cs.fridgeSetting - 2))):  # was -1024))):
+                            integratorUpdate = 0
+                    else:
+                        # integrator action is decreased. Decrease faster than increase.
+                        integratorUpdate *= 2
+                else:
+                    # decrease integral by 1/8 when far from the end value to reset the integrator
+                    integratorUpdate = -(self.cv.diffIntegral / 8)
+
+                self.cv.diffIntegral += integratorUpdate
+
+            # calculate PID parts.
+            print(vars(self.cc))
+            print(vars(self.cv))
+            self.cv.p = self.cc.Kp * self.cv.beerDiff
+            self.cv.i = self.cc.Ki * self.cv.diffIntegral
+            self.cv.d = self.cc.Kd * self.cv.beerSlope
+            newFridgeSetting = self.cs.beerSetting
+            newFridgeSetting += self.cv.p
+            newFridgeSetting += self.cv.i
+            newFridgeSetting += self.cv.d
+            # constrain to tempSettingMin or beerSetting - pidMAx, whichever is lower.
+            lowerBound = self.cc.tempSettingMin if (
+            self.cs.beerSetting <= self.cc.tempSettingMin + self.cc.pidMax) else (self.cs.beerSetting - self.cc.pidMax)
+            # constrain to tempSettingMax or beerSetting + pidMAx, whichever is higher.
+            upperBound = self.cc.tempSettingMax if (
+            self.cs.beerSetting >= self.cc.tempSettingMax - self.cc.pidMax) else (self.cs.beerSetting + self.cc.pidMax)
+            # cs.fridgeSetting = constrain(constrainTemp16(newFridgeSetting), lowerBound, upperBound);
+            self.cs.fridgeSetting = max(lowerBound, min(newFridgeSetting, upperBound))
+
+        elif (self.cs.mode == MODES['MODE_FRIDGE_CONSTANT']):
+            # FridgeTemperature is set manually, disable beer setpoint
+            self.cs.beerSetting = None  # DISABLED_TEMP;
+
+    def updateState(self):
+
+        print("Update state. Mode %s, state %s" %
+              ({v: k for k, v in MODES.items()}[self.cs.mode],
+               {v: k for k, v in STATES.items()}[self.state]))
+
+        stayIdle = False
+        newDoorOpen = self.door.isOpen
+
+        if (newDoorOpen != self.doorOpen):
+            self.doorOpen = newDoorOpen
+            print("Fridge door %s" % ('opened' if self.doorOpen else 'closed'))
+            self.piLink.printFridgeAnnotation("Fridge door %s" %
+                                              ("opened" if self.doorOpen  else "closed"))
+
+        if (self.cs.mode == MODES['MODE_OFF']):
+            self.state = STATES['STATE_OFF']
+            stayIdle = True
+
+        # stay idle when one of the required sensors is disconnected,
+        # or the fridge setting is INVALID_TEMP
+        # FIXME: if(isDisabledOrInvalid(cs.fridgeSetting) ||
+        # !fridgeSensor->isConnected() ||
+        # (!beerSensor->isConnected() && tempControl.modeIsBeer())):
+        #	self.state = 'IDLE'
+        #	stayIdle = True
+
+        sinceIdle = self.timeSinceIdle()
+        sinceCooling = self.timeSinceCooling()
+        sinceHeating = self.timeSinceHeating()
+        fridgeFast = self.fridgeSensor.readFastFiltered()
+        beerFast = self.beerSensor.readFastFiltered()
+        secs = ticks.seconds()
+
+        if self.state in (STATES['IDLE'], STATES['STATE_OFF'],
+                          STATES['WAITING_TO_COOL'], STATES['WAITING_TO_HEAT'],
+                          STATES['WAITING_FOR_PEAK_DETECT']):
+            self.lastIdleTime = secs
+            if not stayIdle:
+                # set waitTime to zero. It will be set to the maximum
+                # required waitTime below when wait is in effect.
+                # if(stayIdle):
+                #	break
+                self.resetWaitTime()
+                if (fridgeFast > (self.cs.fridgeSetting + self.cc.idleRangeHigh)):  # fridge temperature is too high
+                    self.updateWaitTime(MIN_SWITCH_TIME, sinceHeating)
+                    if (self.cs.mode == MODES['MODE_FRIDGE_CONSTANT']):
+                        self.updateWaitTime(MIN_COOL_OFF_TIME_FRIDGE_CONSTANT, sinceCooling)
+                    else:
+                        if (beerFast < (
+                            self.cs.beerSetting + 0.03125)):  # + 16) ):	# If beer is already under target, stay/go to idle. 1/2 sensor bit idle zone
+                            self.state = STATES['IDLE']  # beer is already colder than setting, stay in or go to idle
+                        # break # FIXME: We need to skip the next if statement
+                        else:
+                            self.updateWaitTime(MIN_COOL_OFF_TIME, sinceCooling)
+                    if (self.cooler != None):  # FIXME was &defaultActuator):
+                        if (self.getWaitTime() > 0):
+                            self.state = STATES['WAITING_TO_COOL']
+                        else:
+                            self.state = STATES['COOLING']
+                elif (fridgeFast < (self.cs.fridgeSetting + self.cc.idleRangeLow)):  # fridge temperature is too low
+                    print("Fridge temperature is too low")
+                    self.updateWaitTime(MIN_SWITCH_TIME, sinceCooling)
+                    self.updateWaitTime(MIN_HEAT_OFF_TIME, sinceHeating)
+                    if (self.cs.mode != MODES['MODE_FRIDGE_CONSTANT']):
+                        if (beerFast > (
+                            self.cs.beerSetting - 0.03125)):  # - 16)){ // If beer is already over target, stay/go to idle. 1/2 sensor bit idle zone
+                            self.state = STATES['IDLE']  # beer is already warmer than setting, stay in or go to idle
+                        # break # FIXME: We need to skip the next if statement
+                    # if(self.heater != &defaultActuator or (self.lightAsHeater and (self.light != &defaultActuator))):
+                    # FIXME what is &defaultActuator ?
+                    if ((self.heater != None or
+                             (self.cc.lightAsHeater and (self.light != None)))):
+                        if (self.getWaitTime() > 0):
+                            self.state = STATES['WAITING_TO_HEAT']
+                        else:
+                            self.state = STATES['HEATING']
+                else:
+                    self.state = STATES['IDLE']  # within IDLE range, always go to IDLE
+                # break
+
+            if (self.state == STATES['HEATING']
+                or self.state == STATES['COOLING']):
+                # If peak detect is not finished, but the fridge wants to switch to heat/cool
+                # Wait for peak detection and show on display
+                if self.doNegPeakDetect:
+                    self.updateWaitTime(COOL_PEAK_DETECT_TIME, sinceCooling)
+                    self.state = STATES['WAITING_FOR_PEAK_DETECT']
+                elif self.doPosPeakDetect:
+                    self.updateWaitTime(HEAT_PEAK_DETECT_TIME, sinceHeating)
+                    self.state = STATES['WAITING_FOR_PEAK_DETECT']
+
+        elif self.state in (STATES['COOLING'], STATES['COOLING_MIN_TIME']):
+            self.doNegPeakDetect = True
+            self.lastCoolTime = secs
+            self.updateEstimatedPeak(self.cc.maxCoolTimeForEstimate, self.cs.coolEstimator, sinceIdle)
+            self.state = STATES['COOLING']  # set to cooling here, so the display of COOLING/COOLING_MIN_TIME is correct
+            # stop cooling when estimated fridge temp peak lands on target or if beer is already too cold (1/2 sensor bit idle zone)
+            if (self.cv.estimatedPeak <= self.cs.fridgeSetting
+                or (self.cs.mode != MODES['MODE_FRIDGE_CONSTANT']
+                    and beerFast < (self.cs.beerSetting - 0.03125))):
+                if (sinceIdle > MIN_COOL_ON_TIME):
+                    self.cv.negPeakEstimate = self.cv.estimatedPeak  # remember estimated peak when I switch to IDLE, to adjust estimator later
+                    self.state = STATES['IDLE']
+                # break
+                else:
+                    self.state = STATES['COOLING_MIN_TIME']
+                # break
+
+        elif self.state in (STATES['HEATING'], STATES['HEATING_MIN_TIME']):
+            self.doPosPeakDetect = True
+            self.lastHeatTime = secs
+            self.updateEstimatedPeak(self.cc.maxHeatTimeForEstimate, self.cs.heatEstimator, sinceIdle)
+            self.state = STATES[
+                'HEATING']  # reset to heating here, so the display of HEATING/HEATING_MIN_TIME is correct
+            # stop heating when estimated fridge temp peak lands on target or if beer is already too warm (1/2 sensor bit idle zone)
+            if (self.cv.estimatedPeak >= self.cs.fridgeSetting
+                or (self.cs.mode != MODES['MODE_FRIDGE_CONSTANT']
+                    and beerFast > (self.cs.beerSetting + 0.03125))):
+                if (sinceIdle > MIN_HEAT_ON_TIME):
+                    self.cv.posPeakEstimate = self.cv.estimatedPeak  # remember estimated peak when I switch to IDLE, to adjust estimator later
+                    self.state = STATES['IDLE']
+                # break
+                else:
+                    self.state = STATES['HEATING_MIN_TIME']
+                # break
+
+        elif self.state in (STATES['DOOR_OPEN']):
+            pass  # do nothing
+        else:
+            logging.debug("Unknown state in updatePID: %s" % self.state)
+
+    def updateEstimatedPeak(self, timeLimit, estimator, sinceIdle):
+        activeTime = min(timeLimit, sinceIdle)  # heat or cool time in seconds
+        estimatedOvershoot = (estimator * activeTime) / 3600  # overshoot estimator is in overshoot per hour
+        if (self.stateIsCooling()):
+            estimatedOvershoot = -estimatedOvershoot  # when cooling subtract overshoot from fridge temperature
+        self.cv.estimatedPeak = self.fridgeSensor.readFastFiltered() + estimatedOvershoot
+
+    def updateOutputs(self):
+        if (self.cs.mode == MODES['MODE_TEST']):
+            return
+        # cameraLight.update();
+        heating = self.stateIsHeating()
+        cooling = self.stateIsCooling()
+        self.cooler.set_output(cooling)
+        self.heater.set_output(heating)
+
+    # light->setActive(isDoorOpen() || (cc.lightAsHeater && heating) || cameraLightState.isActive());
+    # fan->setActive(heating || cooling);
+
+
+    def detectPeaks(self):
+        """Detect peaks in fridge temperature to tune overshoot estimators."""
+        # LOG_ID_TYPE detected = 0;
+        detected = None
+        peak = estimate = error = oldEstimator = newEstimator = None
+        if (self.doPosPeakDetect and not self.stateIsHeating()):
+            # FIXME: Either of these could be None.  Used to be INVALID_TEMP, so the maths would work.
+            # INVALID_TEMP = -32768
+            # error = peak - estimate
+            # peak is invalid, error is very -ve
+            # estimate is invalid, error
+
+            peak = self.fridgeSensor.detectPosPeak()
+            estimate = self.cv.posPeakEstimate
+            # if peak is not None:	# FIXME: This could be moved into if statement below
+            #	error = peak - estimate
+            oldEstimator = self.cs.heatEstimator
+            if peak is not None:  # INVALID_TEMP):
+                # positive peak detected
+                error = peak - estimate
+                if (error > self.cc.heatingTargetUpper):
+                    # Peak temperature was higher than the estimate.
+                    # Overshoot was higher than expected
+                    # Increase estimator to increase the estimated overshoot
+                    self.increaseEstimator(self.cs.heatEstimator, error)
+
+                if (error < self.cc.heatingTargetLower):
+                    # Peak temperature was lower than the estimate.
+                    # Overshoot was lower than expected
+                    # Decrease estimator to decrease the estimated overshoot
+                    self.decreaseEstimator(self.cs.heatEstimator, error)
+
+                detected = 'INFO_POSITIVE_PEAK'
+
+            elif (self.timeSinceHeating() > HEAT_PEAK_DETECT_TIME):
+                if (self.fridgeSensor.readFastFiltered()
+                        < (self.cv.posPeakEstimate + self.cc.heatingTargetLower)):
+                    # Idle period almost reaches maximum allowed time for peak detection
+                    # This is the heat, then drift up too slow (but in the right direction).
+                    # estimator is too high
+                    peak = self.fridgeSensor.readFastFiltered()
+                    self.decreaseEstimator(self.cs.heatEstimator, error)
+                    detected = 'INFO_POSITIVE_DRIFT'
+
+                else:
+                    # maximum time for peak estimation reached
+                    self.doPosPeakDetect = False
+
+            if detected:
+                newEstimator = self.cs.heatEstimator
+                self.cv.posPeak = peak
+                self.doPosPeakDetect = False
+
+        elif (self.doNegPeakDetect and not self.stateIsCooling()):
+            # FIXME: Either of these could be None.  Used to be INVALID_TEMP, so the maths would work.
+            peak = self.fridgeSensor.detectNegPeak()
+            estimate = self.cv.negPeakEstimate
+            print("peak %s : estimate %s" % (peak, estimate))
+            # if peak is not None:	# FIXME: This could be moved into if statement below
+            #	error = peak - estimate	# FIXME: Crash if estimate is None
+            oldEstimator = self.cs.coolEstimator
+            if (peak != None):  # INVALID_TEMP):
+                # negative peak detected
+                error = peak - estimate  # FIXME: Crash if estimate is None
+                if (error < self.cc.coolingTargetLower):
+                    # Peak temperature was lower than the estimate.
+                    # Overshoot was higher than expected
+                    # Increase estimator to increase the estimated overshoot
+                    self.increaseEstimator(self.cs.coolEstimator, error)
+                if (error > self.cc.coolingTargetUpper):
+                    # Peak temperature was higher than the estimate.
+                    # Overshoot was lower than expected
+                    # Decrease estimator to decrease the estimated overshoot
+                    self.decreaseEstimator(self.cs.coolEstimator, error)
+
+                detected = 'INFO_NEGATIVE_PEAK'
+
+            elif (self.timeSinceCooling() > COOL_PEAK_DETECT_TIME):
+                if (self.fridgeSensor.readFastFiltered()
+                        > (self.cv.negPeakEstimate + self.cc.coolingTargetUpper)):
+                    # Idle period almost reaches maximum allowed time for peak detection
+                    # This is the cooling, then drift down too slow (but in the right direction).
+                    # estimator is too high
+                    peak = self.fridgeSensor.readFastFiltered()
+                    self.decreaseEstimator(self.cs.coolEstimator, error)  # FIXME: error is not known here
+                    detected = 'INFO_NEGATIVE_DRIFT'
+                else:
+                    # maximum time for peak estimation reached
+                    self.doNegPeakDetect = False
+
+            if detected:
+                newEstimator = self.cs.coolEstimator
+                self.cv.negPeak = peak
+                self.doNegPeakDetect = False
+
+        if detected:
+            # send out log message for type of peak detected
+            # logInfoTempTempFixedFixed(detected, peak, estimate, oldEstimator, newEstimator)
+            logging.info("Peak detected: %s %s %s %s %s" % (detected, peak, estimate, oldEstimator, newEstimator))
+
+    def increaseEstimator(self, estimator, error):
+        """Increase estimator at least 20%, max 50%."""
+        # temperature factor = 614 + constrainTemp(abs(error)>>5, 0, 154);
+        # // 1.2 + 3.1% of error, limit between 1.2 and 1.5
+        factor = 1.2 + max(0, min(abs(error) * 0.031, 0.3))  # 1.2 + 3.1% of error, limit between 1.2 and 1.5
+        estimator *= factor
+        if (estimator < 0.05):
+            estimator = 0.05  # make estimator at least 0.05
+        # FIXME: eepromManager.storeTempSettings();
+
+    def decreaseEstimator(self, estimator, error):
+        """Decrease estimator at least 16.7% (1/1.2), max 33.3% (1/1.5)."""
+        # temperature factor = 426 - constrainTemp(abs(error)>>5, 0, 85);
+        # // 0.833 - 3.1% of error, limit between 0.667 and 0.833
+        factor = 0.833 - max(0, min(abs(error) * 0.031, 0.166))  # 0.833 - 3.1% of error, limit between 0.667 and 0.833
+        estimator *= factor
+
+    # FIXME: eepromManager.storeTempSettings();
+
+
+    def timeSinceCooling(self):
+        return ticks.timeSince(self.lastCoolTime)
+
+    def timeSinceHeating(self):
+        return ticks.timeSince(self.lastHeatTime)
+
+    def timeSinceIdle(self):
+        return ticks.timeSince(self.lastIdleTime)
+
+    def loadDefaultSettings(self):
+        # if BREWPI_EMULATE
+        #	setMode(MODE_BEER_CONSTANT);
+        # else
+        #	setMode(MODE_OFF);
+        # endif
+        self.setMode(MODES['MODE_OFF'])
+        self.cs.beerSetting = None  # start with no temp settings
+        self.cs.fridgeSetting = None
+        self.cs.heatEstimator = 0.2  # intToTempDiff(2)/10; // 0.2
+        self.cs.coolEstimator = 5  # intToTempDiff(5);
+
+    def storeConstants(self):
+        """Write variables in cc class to EEPROM (file)."""
+        with open('EEPROM.cc', 'wb') as f:
+            pickle.dump(vars(self.cc), f, pickle.HIGHEST_PROTOCOL)
+
+    def loadConstants(self):
+        """Read variables in cc class from EEPROM (file)."""
+        with open('EEPROM.cc', 'rb') as f:
+            data = pickle.load(f)
+
+        self.cc.__dict__.update(data)
+
+        self.initFilters()
+
+    def storeSettings(self):
+        """Write variables in cs class to EEPROM (file)."""
+        with open('EEPROM.cs', 'wb') as f:
+            pickle.dump(vars(self.cs), f, pickle.HIGHEST_PROTOCOL)
+        self.storedBeerSetting = self.cs.beerSetting
+
+    def loadSettings(self):
+        """Read variables in cs class from EEPROM (file)."""
+        with open('EEPROM.cs', 'rb') as f:
+            data = pickle.load(f)
+
+        self.cs.__dict__.update(data)
+
+        logging.debug("loaded settings")
+        self.storedBeerSetting = self.cs.beerSetting
+        self.setMode(self.cs.mode, True)  # Force the mode update
+
+    def loadDefaultConstants(self):
+        # See ControlConstants class definition for descriptions
+        self.cc.tempFormat = 'C'
+        self.cc.tempSettingMin = 1
+        self.cc.tempSettingMax = 30
+        self.cc.Kp = 5.0
+        self.cc.Ki = 0.35
+        self.cc.Kd = 2.5
+        self.cc.iMaxError = 0.5
+        self.cc.idleRangeHigh = 1
+        self.cc.idleRangeLow = -1
+        self.cc.heatingTargetUpper = 0.3
+        self.cc.heatingTargetLower = -0.2
+        self.cc.coolingTargetUpper = 0.2
+        self.cc.coolingTargetLower = -0.3
+        self.cc.maxHeatTimeForEstimate = 600
+        self.cc.maxCoolTimeForEstimate = 1200
+        self.cc.fridgeFastFilter = 1
+        self.cc.fridgeSlowFilter = 4
+        self.cc.fridgeSlopeFilter = 3
+        self.cc.beerFastFilter = 3
+        self.cc.beerSlowFilter = 4
+        self.cc.beerSlopeFilter = 4
+        self.cc.lightAsHeater = 0
+        self.cc.rotaryHalfSteps = 0
+        self.cc.pidMax = 10
+
+        self.initFilters()
+
+    def initFilters(self):
+        self.fridgeSensor.setFastFilterCoefficients(self.cc.fridgeFastFilter)
+        self.fridgeSensor.setSlowFilterCoefficients(self.cc.fridgeSlowFilter)
+        self.fridgeSensor.setSlopeFilterCoefficients(self.cc.fridgeSlopeFilter)
+        self.beerSensor.setFastFilterCoefficients(self.cc.beerFastFilter)
+        self.beerSensor.setSlowFilterCoefficients(self.cc.beerSlowFilter)
+        self.beerSensor.setSlopeFilterCoefficients(self.cc.beerSlopeFilter)
+
+    def setMode(self, newMode, force=False):
+        logging.debug("TempControl::setMode from %s to %s", self.cs.mode, newMode)
+
+        if (newMode != self.cs.mode or self.state == STATES['WAITING_TO_HEAT']
+            or self.state == STATES['WAITING_TO_COOL']
+            or self.state == STATES['WAITING_FOR_PEAK_DETECT']):
+            self.state = STATES['IDLE']
+            force = True
+
+        if (force):
+            self.cs.mode = newMode
+            if (newMode == MODES['MODE_OFF']):
+                self.cs.beerSetting = None
+                self.cs.fridgeSetting = None
+
+            # FIXME: eepromManager.storeTempSettings()
+
+    def getBeerTemp(self):
+        if (self.beerSensor.isConnected()):
+            return self.beerSensor.readFastFiltered()
+        else:
+            return None
+
+    def getBeerSetting(self):
+        return self.cs.beerSetting
+
+    def getFridgeTemp(self):
+        if (self.fridgeSensor.isConnected()):
+            return self.fridgeSensor.readFastFiltered()
+        else:
+            return None
+
+    def getFridgeSetting(self):
+        return self.cs.fridgeSetting
+
+    def setBeerTemp(self, newTemp):
+        oldBeerSetting = self.cs.beerSetting
+        self.cs.beerSetting = newTemp
+        if (oldBeerSetting is None or (
+            abs(oldBeerSetting - newTemp) > 0.5)):  # more than half degree C difference with old setting
+            self.reset()  # reset controller
+        self.updatePID()
+        self.updateState()
+
+    # FIXME: Implement this
+    # if (self.cs.mode != MODES['MODE_BEER_PROFILE']
+    #	or abs(self.storedBeerSetting - newTemp) > 0.25):
+    # more than 1/4 degree C difference with EEPROM
+    # Do not store settings every time in profile mode, because EEPROM has limited number of write cycles.
+    # A temperature ramp would cause a lot of writes
+    # If Raspberry Pi is connected, it will update the settings anyway. This is just a safety feature.
+    # FIXME: eepromManager.storeTempSettings()
+
+
+    def setFridgeTemp(self, newTemp):
+        self.cs.fridgeSetting = newTemp
+        self.reset()  # reset peak detection and PID
+        self.updatePID()
+        self.updateState()
+
+    # FIXME eepromManager.storeTempSettings()
+
+
+    def stateIsCooling(self):
+        return self.state in (STATES['COOLING'],
+                              STATES['COOLING_MIN_TIME'])
+
+    def stateIsHeating(self):
+        return self.state in (STATES['HEATING'],
+                              STATES['HEATING_MIN_TIME'])
+
+    def getRoomTemp(self):
+        return self.ambientSensor.temperature
+
+    def getMode(self):
+        return self.cs.mode
+
+    def getState(self):
+        return self.state
+
+    def getWaitTime(self):
+        return self.waitTime
+
+    def resetWaitTime(self):
+        self.waitTime = 0
+
+    def updateWaitTime(self, newTimeLimit, newTimeSince):
+        if (newTimeSince < newTimeLimit):
+            self.newWaitTime = newTimeLimit - newTimeSince
+            if (self.newWaitTime > self.waitTime):
+                self.waitTime = self.newWaitTime
+
+    def isDoorOpen(self):
+        return self.doorOpen
+
+    def getDisplayState(self):
+        return STATES['DOOR_OPEN'] if self.isDoorOpen() else self.getState()

--- a/fuscus/tempControl.py
+++ b/fuscus/tempControl.py
@@ -768,29 +768,35 @@ class tempController:
         return STATES['DOOR_OPEN'] if self.isDoorOpen() else self.getState()
 
     # Convert celsius to fahrenheit, and vice versa
-    def temp_convert(self, temp, original_units, desired_units):
+    def temp_convert(self, temp, original_units, desired_units, diff=False):
         if original_units == desired_units:
             return temp
 
         if original_units == "C" and desired_units == "F":
-            return temp * 1.8 + 32
+            if diff:
+                return temp * 1.8
+            else:
+                return temp * 1.8 + 32
         elif original_units == "F" and desired_units == "C":
-            return (temp - 32) / 1.8
+            if diff:
+                return temp / 1.8
+            else:
+                return (temp - 32) / 1.8
         else:
             logging.error("Invalid units passed to temp_convert. Orig: {}, Desired: {}".format(original_units,
                                                                                                desired_units))
             return None  # Should probably return something other than none, or raise an error.
 
     # Converts a temperature to the external value (C or F)
-    def temp_convert_to_external(self, temp):
-        if temp:
-            return self.temp_convert(temp, "C", self.cc.tempFormat)
+    def temp_convert_to_external(self, temp, diff=False):
+        if temp is not None:
+            return self.temp_convert(temp, "C", self.cc.tempFormat, diff)
         return temp  # Returns None if that's what we were passed
 
     # Converts a temperature to the internal value (C)
-    def temp_convert_to_internal(self, temp):
-        if temp:
-            return self.temp_convert(temp, self.cc.tempFormat, "C")
+    def temp_convert_to_internal(self, temp, diff=False):
+        if temp is not None:
+            return self.temp_convert(temp, self.cc.tempFormat, "C", diff)
         return temp  # Returns None if that's what we were passed
 
     # When we convert from C to F (or vice versa) we need to convert all the control variables


### PR DESCRIPTION
There's a handful of changes in this pull request:
- Added basic (beta) support for converting to Fahrenheit
- Converted piLink.py and tempControl.py to use PEP8 indentation
- Fixed a bug that was causing Fuscus to interpret its status output as control input
- Added checks to tempControl.updateState to prevent the controller from crashing if a beer profile was set without a fridge setting already being enabled

The Fahrenheit changes are only implemented in code that talks to the outside world. That is - internally, everything remains in Celsius - only the code that talks to BrewPi or the LCD screen attempt to convert between units. I would consider this support "beta" at the moment - mostly because I'm not yet 100% certain that I caught every instance where something denominated in degrees was being passed to/from the controller.
