### PR TITLE
Add eeprom support

### DIFF
--- a/fuscus/EepromManager.py
+++ b/fuscus/EepromManager.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+# /*
+#  * Copyright 2013 BrewPi/Elco Jacobs.
+#  * Copyright 2013 Matthew McGowan
+#  *
+#  * This file is part of BrewPi.
+#  *
+#  * BrewPi is free software: you can redistribute it and/or modify
+#  * it under the terms of the GNU General Public License as published by
+#  * the Free Software Foundation, either version 3 of the License, or
+#  * (at your option) any later version.
+#  *
+#  * BrewPi is distributed in the hope that it will be useful,
+#  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  * GNU General Public License for more details.
+#  *
+#  * You should have received a copy of the GNU General Public License
+#  * along with BrewPi.  If not, see <http://www.gnu.org/licenses/>.
+#  */
+
+
+
+class eepromManager:
+    def __init__(self, tempControl):
+        self.settings_are_loaded = False
+        self.tempControl = tempControl
+        self.tempControl.eepromManager = self  # This is bad practice, but it accomplishes what the firmware needs
+
+    def hasSettings(self):
+        # In the arduino version, this works by reading a "version" number which is saved to the eeprom and returning
+        # that. Instead, we'll test if the 'settings' files exist - and return True or False based on that.
+        # That check, however, lives in the tempControl class (because that's where the eeprom settings load/save
+        # functionality exists)
+        return self.tempControl.hasStoredSettings()
+
+    def zapEeprom(self):
+        # In the arduino version, this is implmented by writing over the eeprom with 0xFF. Instead, we're going to
+        # just delete the two files. Since those files are created/managed in tempControl, I've moved the code there.
+        self.tempControl.zapStoredSettings()
+
+    def initializeEeprom(self):
+        # Fundamentally, the arduino version of this does the following:
+        # 1. Zap the eeprom
+        self.zapEeprom()
+        # TODO - 2. Set up unconfigured devices
+        #     deviceManager.setupUnconfiguredDevices();
+        # 3. Load default constants
+        self.tempControl.loadDefaultConstants()
+        # 4. Load default settings
+        self.tempControl.loadDefaultSettings()
+        # 5. Save constants / 6. Save settings
+        self.storeTempConstantsAndSettings()
+        # 7. Store the version flag - Note - this is deprecated in Fuscus by tempControl.hasStoredSettings
+        # 8. Save devices
+        self.saveDefaultDevices()  # This doesn't do anything.
+        # 9. Initialize temperature control
+        self.tempControl.initFilters()
+
+
+    def saveDefaultDevices(self):
+        return False  # Appears to be unimplemented in the original file
+
+
+    def applySettings(self):
+        # If there aren't any settings saved, load the defaults & then write them out to a file.
+        if not self.hasSettings():
+            self.tempControl.loadDefaultConstants()
+            self.tempControl.loadDefaultSettings()
+            # TODO - Implement deviceManager.setupUnconfiguredDevices()
+            self.storeTempConstantsAndSettings()  # NOTE - This isn't actually called in the Arduino version
+            return True
+
+        #
+        # 	// start from a clean state
+        # 	deviceManager.setupUnconfiguredDevices();
+        #
+        # 	logDebug("Applying settings");
+        #
+        # 	// load the one chamber and one beer for now
+        self.tempControl.loadConstants()
+        self.tempControl.loadSettings()
+        # 	logDebug("Applied settings");
+
+        # TODO - Implement device configuration
+
+        # 	DeviceConfig deviceConfig;
+        # 	for (uint8_t index = 0; fetchDevice(deviceConfig, index); index++)
+        # 	{
+        # 		if (deviceManager.isDeviceValid(deviceConfig, deviceConfig, index))
+        # 			deviceManager.installDevice(deviceConfig);
+        # 		else {
+        # 			clear((uint8_t*)&deviceConfig, sizeof(deviceConfig));
+        # 			eepromManager.storeDevice(deviceConfig, index);
+        # 		}
+        # 	}
+        # 	return true;
+        # }
+        return True
+
+
+    def storeTempSettings(self):
+        self.tempControl.storeSettings()
+
+    def storeTempConstantsAndSettings(self):
+        self.tempControl.storeConstants()
+        self.storeTempSettings()
+
+
+    def fetchDevice(self):
+        # TODO - Implement
+        # bool EepromManager::fetchDevice(DeviceConfig& config, uint8_t deviceIndex)
+        # {
+        #     bool ok = (hasSettings() && deviceIndex<EepromFormat::MAX_DEVICES);
+        #     if (ok)
+        #         eepromAccess.readBlock(&config, pointerOffset(devices)+sizeof(DeviceConfig)*deviceIndex, sizeof(DeviceConfig));
+        #     return ok;
+        # }
+        pass
+
+    def storeDevice(self):
+        # TODO - Implement
+        # bool EepromManager::storeDevice(const DeviceConfig& config, uint8_t deviceIndex)
+        # {
+        #     bool ok = (hasSettings() && deviceIndex<EepromFormat::MAX_DEVICES);
+        #     if (ok)
+        #         eepromAccess.writeBlock(pointerOffset(devices)+sizeof(DeviceConfig)*deviceIndex, &config, sizeof(DeviceConfig));
+        #     return ok;
+        # }
+        pass
+

--- a/fuscus/EepromManager.py
+++ b/fuscus/EepromManager.py
@@ -58,10 +58,8 @@ class eepromManager:
         # 9. Initialize temperature control
         self.tempControl.initFilters()
 
-
     def saveDefaultDevices(self):
         return False  # Appears to be unimplemented in the original file
-
 
     def applySettings(self):
         # If there aren't any settings saved, load the defaults & then write them out to a file.
@@ -99,14 +97,12 @@ class eepromManager:
         # }
         return True
 
-
     def storeTempSettings(self):
         self.tempControl.storeSettings()
 
     def storeTempConstantsAndSettings(self):
         self.tempControl.storeConstants()
         self.storeTempSettings()
-
 
     def fetchDevice(self):
         # TODO - Implement
@@ -129,4 +125,3 @@ class eepromManager:
         #     return ok;
         # }
         pass
-

--- a/fuscus/constants.py
+++ b/fuscus/constants.py
@@ -24,6 +24,7 @@ import configparser
 import argparse
 
 import tempControl
+import EepromManager
 import relay
 import rotaryEncoder
 import pcd8544
@@ -188,6 +189,8 @@ LCD = lcd.lcd(lines=6, chars=20, hardware=LCD_hardware)
 tempControl = tempControl.tempController(ID_fridge, ID_beer, ID_ambient,
                                          cooler=cooler, heater=heater, door=DOOR)
 
-piLink = piLink.piLink(tempControl=tempControl, path=config['port'].get('path'))
+eepromManager = EepromManager.eepromManager(tempControl=tempControl)
+
+piLink = piLink.piLink(tempControl=tempControl, path=config['port'].get('path'), eepromManager=eepromManager)
 
 menu = Menu.Menu(encoder=encoder, tempControl=tempControl, piLink=piLink)

--- a/fuscus/fuscus.py
+++ b/fuscus/fuscus.py
@@ -60,18 +60,16 @@ def killhandle(signum, frame):
 
 
 def setup():
-    # resetEeprom = platform_init()	# FIXME: not implemented
-    # eepromManager.init()	# FIXME: not implemented
+    # resetEeprom = platform_init()	# Not needed for Fuscus - This initialzies the eeprom access
+    # eepromManager.init()	# Not needed for Fuscus - This checks the eeprom size on Arduino to ensure validity
     # ui.init()
     # f,portName=piLink.init()
     print("started")
     logging.debug("started")
     # tempControl.init()
-    # settingsManager.loadSettings()	# FIXME No settings manager
-    # FIXME The next two lines are temporary code to make things work.
-    # They should be done by the settings manager.
-    tempControl.loadDefaultSettings()
-    tempControl.loadDefaultConstants()
+
+    # This loads the settings if saved (and the defaults, if not)
+    eepromManager.applySettings()  # NOTE - This replaces settingsManager.loadSettings()
 
     start = time.time()
     delay = ui.showStartupPage(piLink.portName)


### PR DESCRIPTION
This adds 'eeprom' (setting saving/loading) support. Key notes:
- Added EepromManager.py
- Added SettingsManager.py
- Added tempControl.hasStoredSettings and tempControl.zapStoredSettings

SettingsManager.py was virtually unused in the original Arduino implementation, serving only to help break out "debug" code. As we don't use this mode in Fuscus, I've replaced it by merging the relevant code into the eepromManager class.

The two new methods in tempControl were not in the Arduino implementation. They are added to obviate a hack done in the original eepromManager with version numbers that was originally intended to determine if settings had previously been loaded. 
