### PR TITLE
Temperature Calibration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
+
+# Ignore the individual fuscus.ini file
+fuscus.ini

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -24,8 +24,9 @@ login as **fuscus**
 *echo "fuscus/" >> .git/info/sparse-checkout*  
 *git pull origin master*  
 Now the source is in /fuscus, with no docs or other files.
-13. Change to the fuscus directory and edit the **fuscus.ini** to include your temperature sensor IDs and other settings.  
+13. Change to the fuscus directory and edit the **fuscus.ini** to include your temperature sensor IDs and other settings. A sample fuscus.ini is saved as **fuscus.sample.ini**.  
 *cd fuscus*  
+*cp fuscus.sample.ini*
 *nano fuscus.ini*
 14. Run fuscus  
 *sudo ./fuscus.py*

--- a/fuscus/constants.py
+++ b/fuscus/constants.py
@@ -189,6 +189,15 @@ LCD = lcd.lcd(lines=6, chars=20, hardware=LCD_hardware)
 tempControl = tempControl.tempController(ID_fridge, ID_beer, ID_ambient,
                                          cooler=cooler, heater=heater, door=DOOR)
 
+# Set the temperature calibration offsets (if available)
+# FIXME - This should be part of deviceManager & saved to/loaded from the eeprom
+if ID_fridge and config['sensors'].get('fridge_offset'):
+    tempControl.fridgeSensor.calibrationOffset = float(config['sensors'].get('fridge_offset'))
+if ID_beer and config['sensors'].get('beer_offset'):
+    tempControl.fridgeSensor.calibrationOffset = float(config['sensors'].get('beer_offset'))
+if ID_ambient and config['sensors'].get('ambient_offset'):
+    tempControl.fridgeSensor.calibrationOffset = float(config['sensors'].get('ambient_offset'))
+
 eepromManager = EepromManager.eepromManager(tempControl=tempControl)
 
 piLink = piLink.piLink(tempControl=tempControl, path=config['port'].get('path'), eepromManager=eepromManager)

--- a/fuscus/fuscus.sample.ini
+++ b/fuscus/fuscus.sample.ini
@@ -1,0 +1,100 @@
+[port]
+# Define the path to communicate with this instance of fuscus
+path = /dev/fuscus
+
+
+[sensors]
+# Define the sensor one-wire addresses here
+# You can find the address of the devices on your system by typing the
+# following at a command prompt:
+#
+# ls /sys/bus/w1/devices/
+#
+# Make sure to define the correct sensor for fridge, beer and ambient.
+# You must specify at least the fridge sensor.
+# e.g.
+# fridge = 28-000006f02214
+# beer = 28-0315535f7bff
+# ambient = 28-000006f04264
+fridge = 28-031590ed07ff
+ambient = 28-0415a1f1ebff
+
+
+[door]
+# Define the door sensor pin here
+# The recommended default is on pin 3, open when high (True).
+# You can override the pin number, and the logic state which indicates
+# the door is open.
+# If nothing is specified then it is assumed there is no door switch.
+# e.g. pin 3 active high (recommended)
+#pin = 3
+#open_state = True
+
+
+[relay]
+# Define the relay control pins here
+# hot = GPIO pin number for heating relay
+# invert_hot = True for active-low relay boards
+# cold = GPIO pin number for cooling relay
+# invert_cold = True for active-low relay boards
+hot = 16
+invert_hot = True
+cold = 18
+invert_cold = True
+
+
+[ui]
+# Define the local user interface (UI) devices here.
+# Current UI devices are the LCD, rotary encoder, and buzzer.
+#
+# Only the Nokia 5110 with PCD8544 controller is supported,
+# or no display.
+#
+# For no LCD attached:
+# lcd = None
+#
+# For Nokia 5110 display with PCD8544 controller:
+# The DC and RST GPIO pins can be specified.  The backlight LED pin
+# can be specified, or None for no backlight.  The LCD module also
+# uses pins 19, 23 and 24 for SPI communications.  These can not be
+# moved and should not be used for other functions.
+# lcd = pcd8544
+# lcd_DC = 21
+# lcd_RST = 22
+# lcd_LED = 12
+
+lcd = None
+
+# For the rotary encoder, three pins must be specified.  The
+# pushbutton, and the A and B encoder outputs.  It is recommended
+# that the pushbutton be on pin 5, as this can be used to boot
+# a Pi that is in the shutdown state.
+#
+# For no rotary encoder attached:
+# rotary = None
+#
+# For typical rotary encoder attached:
+# rotary = True
+# rotary_PB = 5
+# rotary_A = 13
+# rotary_B = 11
+
+rotary = None
+
+# For the buzzer, only a single GPIO pin must be specified.
+# Currently the buzzer code is not implemented.
+#
+# For no buzzer present:
+# buzzer = None
+#
+# For a buzzer attached (to GPIO 15, for example):
+# buzzer = 15
+
+buzzer = None
+
+
+[network]
+# Define the TCP/IP port number to listen for incoming commands from
+# the web interface.  Default is 25518.
+# Currently not implemented.
+port = 25518

--- a/fuscus/fuscus.sample.ini
+++ b/fuscus/fuscus.sample.ini
@@ -19,6 +19,14 @@ path = /dev/fuscus
 fridge = 28-031590ed07ff
 ambient = 28-0415a1f1ebff
 
+# If your temperature sensors are miscalibrated and reading high/low,
+# calibrate them here. Note that we use degrees celsius internally,
+# so all offsets must be in deg C.
+# Also, make your offsets decimal numbers (IE - 3.0 instead of 3)
+
+fridge_offset = 0.0
+# beer_offset = 0.25
+# ambient_offset = -0.1
 
 [door]
 # Define the door sensor pin here

--- a/fuscus/settingsManager.py
+++ b/fuscus/settingsManager.py
@@ -1,0 +1,5 @@
+# The only purpose of SettingsManager.py was to call applySettings in eepromManager, and load the default settings
+# if it failed. The only time applySettings was called, however, was here.
+
+# For Fuscus, this code has been merged into eepromManager.applySettings
+

--- a/fuscus/tempSensor.py
+++ b/fuscus/tempSensor.py
@@ -35,7 +35,7 @@ import logging
 # This class adds filtering and other functions to the sensor.
 
 class sensor(DS18B20):
-    def __init__(self, deviceID):
+    def __init__(self, deviceID, calibrationOffset=0):
 
         super().__init__(deviceID, samplePeriod=1)
 
@@ -55,6 +55,11 @@ class sensor(DS18B20):
         self.slowFilter = FilterCascaded.CascadedFilter()
         self.slopeFilter = FilterCascaded.CascadedFilter()
         self.prevOutputForSlope = None
+
+        if calibrationOffset is None:
+            self.calibrationOffset = 0
+        else:
+            self.calibrationOffset = calibrationOffset
 
         time.sleep(1)  # Wait for at least one reading to be ready.
 
@@ -76,11 +81,14 @@ class sensor(DS18B20):
 
     def update(self):
         # if (!_sensor || (temp=_sensor->read())==TEMP_SENSOR_DISCONNECTED) {
+        # One big difference between the Arduino code & this code is that _sensor->read() includes the calibration
+        # offsets. To compensate, adding it here.
         temp = self.temperature
         if (temp is None):
             if (self.failedReadCount < 255):  # limit
                 self.failedReadCount += 1
             return
+        temp += self.calibrationOffset
 
         self.fastFilter.add(temp)
         self.slowFilter.add(temp)


### PR DESCRIPTION
This pull request adds support for three new temperature calibration options in fuscus.ini:
- fridge_offset
- beer_offset
- ambient_offset

These are offsets (in degrees Celsius) which are added to every temperature reading from a particular sensor. They are designed to allow for tweaking sensors that are not properly factory calibrated.
